### PR TITLE
Add anchor links to use case overview table

### DIFF
--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -41,63 +41,63 @@ Find use cases by what you need to get done:
 
 | # | Use Case | Role | Key Metric |
 |---|----------|------|------------|
-| 1 | AI Code Reviewer | Dev | 4h → 15min per PR |
-| 2 | AI Test Generator | Dev/QA | 2 days → 30min |
-| 3 | AI Deploy Monitor | DevOps | Manual → Auto (2min MTTR) |
-| 4 | AI API Doc Writer | Dev | 1 week → 2 hours |
-| 5 | AI Debug Assistant | Dev | 2h → 10min |
-| 6 | AI SEO Content Writer | Marketing | 4h → 20min per article |
-| 7 | AI Social Media Manager | Marketing | 3h/day → 15min |
-| 8 | AI Ad Copy Generator | Marketing | 50 → 200 variants in 10min |
-| 9 | AI Newsletter Curator | Marketing | 5h/week → 30min |
-| 10 | AI Competitive Copywriter | Marketing | 2 days → 1 hour |
-| 11 | AI Lead Researcher | Sales | 20 → 200 leads/day |
-| 12 | AI CRM Updater | Sales | 45min/day → 0 |
-| 13 | AI Proposal Generator | Sales | 3h → 15min |
-| 14 | AI Follow-up Writer | Sales | 30min → 2min |
-| 15 | AI Client Research Brief | Sales | 1h → 5min |
-| 16 | AI Quote Calculator | Sales | 2h → 10min |
-| 17 | AI Ticket Classifier | Support | 5min/ticket → instant |
-| 18 | AI Knowledge Base Builder | Support | 2 days → 1 hour |
-| 19 | AI Multi-Language Support | Support | 5 translators → 1 AI |
-| 20 | AI VIP Escalation | Support | 30% missed → 0% |
-| 21 | AI Resume Screener | HR | 3 days → 2 hours |
-| 22 | AI Job Description Writer | HR | 2h → 10min |
-| 23 | AI Interview Scheduler | HR | 45min → 3min |
-| 24 | AI Onboarding Assistant | HR | 2 weeks → 3 days |
-| 25 | AI Expense Auditor | Finance | 20min/report → instant |
-| 26 | AI Financial Report Generator | Finance | 2 days → 3 hours |
-| 27 | AI Invoice Processor | Finance | 15min/invoice → 30sec |
-| 28 | AI Meeting Notes | Operations | 30min → instant |
-| 29 | AI Inventory Forecaster | Operations | Weekly → real-time |
-| 30 | AI Vendor Evaluator | Operations | 1 week → 2 hours |
-| 31 | AI Code Migrator | Dev | 2 weeks → 4 hours |
-| 32 | AI Performance Profiler | Dev | 3 days → 30min |
-| 33 | AI Security Scanner | DevOps | Weekly → continuous |
-| 34 | AI Database Optimizer | Dev | 8h → 20min |
-| 35 | AI Dependency Manager | Dev | 4h/week → 10min |
-| 36 | AI Brand Monitor | Marketing | 3h/day → real-time |
-| 37 | AI Influencer Finder | Marketing | 2 weeks → 2 hours |
-| 38 | AI Campaign Analyzer | Marketing | 1 day → 15min |
-| 39 | AI Content Calendar | Marketing | 4h/week → 20min |
-| 40 | AI Persona Builder | Marketing | 1 week → 1 hour |
-| 41 | AI Sales Forecaster | Sales | 2 days → 30min |
-| 42 | AI Demo Personalizer | Sales | 3h → 15min |
-| 43 | AI Pricing Optimizer | Operations | 1 week → 2 hours |
-| 44 | AI Contract Analyzer | Operations | 4h/contract → 10min |
-| 45 | AI Churn Predictor | Support | Monthly → real-time |
-| 46 | AI Chatbot Trainer | Support | 2 weeks → 3 hours |
-| 47 | AI Bug Prioritizer | Dev | 2h/day → instant |
-| 48 | AI SLA Tracker | Operations | Manual → automated |
-| 49 | AI Sentiment Analyzer | PM | 1 day → 10min |
-| 50 | AI FAQ Generator | Support | 3 days → 2 hours |
-| 51 | AI Employee Pulse | HR | Monthly → weekly |
-| 52 | AI Training Recommender | HR | 1 week → 1 hour |
-| 53 | AI Comp Benchmarker | HR | 2 weeks → 3 hours |
-| 54 | AI Review Writer | HR | 2h/review → 15min |
-| 55 | AI Policy Updater | Operations | 2 days → 3 hours |
-| 56 | AI Cash Flow Forecaster | Finance | 1 day → 30min |
-| 57 | AI Compliance Checker | Operations | 1 week → 4 hours |
-| 58 | AI Process Miner | Operations | 3 weeks → 2 days |
-| 59 | AI Document Classifier | Operations | 5min/doc → instant |
-| 60 | AI Risk Scorer | Operations | 2 days → 2 hours |
+| 1 | [AI Code Reviewer](/use-cases/role/product-dev#_1-ai-code-reviewer) | Dev | 4h → 15min per PR |
+| 2 | [AI Test Generator](/use-cases/role/product-dev#_2-ai-test-generator) | Dev/QA | 2 days → 30min |
+| 3 | [AI Deploy Monitor](/use-cases/role/product-dev#_3-ai-deploy-monitor) | DevOps | Manual → Auto (2min MTTR) |
+| 4 | [AI API Doc Writer](/use-cases/role/product-dev#_4-ai-api-doc-writer) | Dev | 1 week → 2 hours |
+| 5 | [AI Debug Assistant](/use-cases/role/product-dev#_5-ai-debug-assistant) | Dev | 2h → 10min |
+| 6 | [AI SEO Content Writer](/use-cases/role/content-marketing#_1-ai-seo-content-writer) | Marketing | 4h → 20min per article |
+| 7 | [AI Social Media Manager](/use-cases/role/content-marketing#_2-ai-social-media-manager) | Marketing | 3h/day → 15min |
+| 8 | [AI Ad Copy Generator](/use-cases/role/content-marketing#_3-ai-ad-copy-generator) | Marketing | 50 → 200 variants in 10min |
+| 9 | [AI Newsletter Curator](/use-cases/role/content-marketing#_4-ai-newsletter-curator) | Marketing | 5h/week → 30min |
+| 10 | [AI Competitive Copywriter](/use-cases/role/content-marketing#_5-ai-competitive-copywriter) | Marketing | 2 days → 1 hour |
+| 11 | [AI Lead Researcher](/use-cases/role/sales#_1-ai-lead-researcher) | Sales | 20 → 200 leads/day |
+| 12 | [AI CRM Updater](/use-cases/role/sales#_2-ai-crm-updater) | Sales | 45min/day → 0 |
+| 13 | [AI Proposal Generator](/use-cases/role/sales#_3-ai-proposal-generator) | Sales | 3h → 15min |
+| 14 | [AI Follow-up Writer](/use-cases/role/sales#_4-ai-follow-up-writer) | Sales | 30min → 2min |
+| 15 | [AI Client Research Brief](/use-cases/role/sales#_5-ai-client-research-brief) | Sales | 1h → 5min |
+| 16 | [AI Quote Calculator](/use-cases/role/sales#_6-ai-quote-calculator) | Sales | 2h → 10min |
+| 17 | [AI Ticket Classifier](/use-cases/role/customer-support#_1-ai-ticket-classifier) | Support | 5min/ticket → instant |
+| 18 | [AI Knowledge Base Builder](/use-cases/role/customer-support#_2-ai-knowledge-base-builder) | Support | 2 days → 1 hour |
+| 19 | [AI Multi-Language Support](/use-cases/role/customer-support#_3-ai-multi-language-support) | Support | 5 translators → 1 AI |
+| 20 | [AI VIP Escalation](/use-cases/role/customer-support#_4-ai-vip-escalation) | Support | 30% missed → 0% |
+| 21 | [AI Resume Screener](/use-cases/role/hr-recruiting#_1-ai-resume-screener) | HR | 3 days → 2 hours |
+| 22 | [AI Job Description Writer](/use-cases/role/hr-recruiting#_2-ai-job-description-writer) | HR | 2h → 10min |
+| 23 | [AI Interview Scheduler](/use-cases/role/hr-recruiting#_3-ai-interview-scheduler) | HR | 45min → 3min |
+| 24 | [AI Onboarding Assistant](/use-cases/role/hr-recruiting#_4-ai-onboarding-assistant) | HR | 2 weeks → 3 days |
+| 25 | [AI Expense Auditor](/use-cases/role/finance#_1-ai-expense-auditor) | Finance | 20min/report → instant |
+| 26 | [AI Financial Report Generator](/use-cases/role/finance#_2-ai-financial-report-generator) | Finance | 2 days → 3 hours |
+| 27 | [AI Invoice Processor](/use-cases/role/finance#_3-ai-invoice-processor) | Finance | 15min/invoice → 30sec |
+| 28 | [AI Meeting Notes](/use-cases/role/operations#_1-ai-meeting-notes) | Operations | 30min → instant |
+| 29 | [AI Inventory Forecaster](/use-cases/role/operations#_2-ai-inventory-forecaster) | Operations | Weekly → real-time |
+| 30 | [AI Vendor Evaluator](/use-cases/role/operations#_3-ai-vendor-evaluator) | Operations | 1 week → 2 hours |
+| 31 | [AI Code Migrator](/use-cases/role/product-dev#_6-ai-code-migrator) | Dev | 2 weeks → 4 hours |
+| 32 | [AI Performance Profiler](/use-cases/role/product-dev#_7-ai-performance-profiler) | Dev | 3 days → 30min |
+| 33 | [AI Security Scanner](/use-cases/role/product-dev#_8-ai-security-scanner) | DevOps | Weekly → continuous |
+| 34 | [AI Database Optimizer](/use-cases/role/product-dev#_9-ai-database-optimizer) | Dev | 8h → 20min |
+| 35 | [AI Dependency Manager](/use-cases/role/product-dev#_10-ai-dependency-manager) | Dev | 4h/week → 10min |
+| 36 | [AI Brand Monitor](/use-cases/role/content-marketing#_6-ai-brand-monitor) | Marketing | 3h/day → real-time |
+| 37 | [AI Influencer Finder](/use-cases/role/content-marketing#_7-ai-influencer-finder) | Marketing | 2 weeks → 2 hours |
+| 38 | [AI Campaign Analyzer](/use-cases/role/content-marketing#_8-ai-campaign-analyzer) | Marketing | 1 day → 15min |
+| 39 | [AI Content Calendar](/use-cases/role/content-marketing#_9-ai-content-calendar) | Marketing | 4h/week → 20min |
+| 40 | [AI Persona Builder](/use-cases/role/content-marketing#_10-ai-persona-builder) | Marketing | 1 week → 1 hour |
+| 41 | [AI Sales Forecaster](/use-cases/role/sales#_7-ai-sales-forecaster) | Sales | 2 days → 30min |
+| 42 | [AI Demo Personalizer](/use-cases/role/sales#_8-ai-demo-personalizer) | Sales | 3h → 15min |
+| 43 | [AI Pricing Optimizer](/use-cases/role/operations#_4-ai-pricing-optimizer) | Operations | 1 week → 2 hours |
+| 44 | [AI Contract Analyzer](/use-cases/role/operations#_5-ai-contract-analyzer) | Operations | 4h/contract → 10min |
+| 45 | [AI Churn Predictor](/use-cases/role/customer-support#_5-ai-churn-predictor) | Support | Monthly → real-time |
+| 46 | [AI Chatbot Trainer](/use-cases/role/customer-support#_6-ai-chatbot-trainer) | Support | 2 weeks → 3 hours |
+| 47 | [AI Bug Prioritizer](/use-cases/role/product-dev#_11-ai-bug-prioritizer) | Dev | 2h/day → instant |
+| 48 | [AI SLA Tracker](/use-cases/role/operations#_6-ai-sla-tracker) | Operations | Manual → automated |
+| 49 | [AI Sentiment Analyzer](/use-cases/role/product-dev#_12-ai-sentiment-analyzer) | PM | 1 day → 10min |
+| 50 | [AI FAQ Generator](/use-cases/role/customer-support#_7-ai-faq-generator) | Support | 3 days → 2 hours |
+| 51 | [AI Employee Pulse](/use-cases/role/hr-recruiting#_5-ai-employee-pulse) | HR | Monthly → weekly |
+| 52 | [AI Training Recommender](/use-cases/role/hr-recruiting#_6-ai-training-recommender) | HR | 1 week → 1 hour |
+| 53 | [AI Comp Benchmarker](/use-cases/role/hr-recruiting#_7-ai-comp-benchmarker) | HR | 2 weeks → 3 hours |
+| 54 | [AI Review Writer](/use-cases/role/hr-recruiting#_8-ai-review-writer) | HR | 2h/review → 15min |
+| 55 | [AI Policy Updater](/use-cases/role/operations#_7-ai-policy-updater) | Operations | 2 days → 3 hours |
+| 56 | [AI Cash Flow Forecaster](/use-cases/role/finance#_4-ai-cash-flow-forecaster) | Finance | 1 day → 30min |
+| 57 | [AI Compliance Checker](/use-cases/role/finance#_5-ai-compliance-checker) | Operations | 1 week → 4 hours |
+| 58 | [AI Process Miner](/use-cases/role/operations#_8-ai-process-miner) | Operations | 3 weeks → 2 days |
+| 59 | [AI Document Classifier](/use-cases/role/operations#_9-ai-document-classifier) | Operations | 5min/doc → instant |
+| 60 | [AI Risk Scorer](/use-cases/role/operations#_10-ai-risk-scorer) | Operations | 2 days → 2 hours |

--- a/docs/zh/use-cases/index.md
+++ b/docs/zh/use-cases/index.md
@@ -41,63 +41,63 @@
 
 | # | 用例 | 角色 | 核心指标 |
 |---|------|------|---------|
-| 1 | AI代码审查 | 研发 | 4小时→15分钟/PR |
-| 2 | AI测试生成 | 研发/QA | 2天→30分钟 |
-| 3 | AI部署监控 | DevOps | 手动→自动(2分钟MTTR) |
-| 4 | AI API文档 | 研发 | 1周→2小时 |
-| 5 | AI Debug助手 | 研发 | 2小时→10分钟 |
-| 6 | AI SEO写手 | 营销 | 4小时→20分钟/篇 |
-| 7 | AI社媒管理 | 营销 | 3小时/天→15分钟 |
-| 8 | AI广告文案 | 营销 | 50→200变体/10分钟 |
-| 9 | AI Newsletter | 营销 | 5小时/周→30分钟 |
-| 10 | AI竞品文案 | 营销 | 2天→1小时 |
-| 11 | AI线索挖掘 | 销售 | 20→200线索/天 |
-| 12 | AI CRM管家 | 销售 | 45分钟/天→0 |
-| 13 | AI方案生成 | 销售 | 3小时→15分钟 |
-| 14 | AI跟进邮件 | 销售 | 30分钟→2分钟 |
-| 15 | AI客户简报 | 销售 | 1小时→5分钟 |
-| 16 | AI报价计算 | 销售 | 2小时→10分钟 |
-| 17 | AI工单分类 | 客服 | 5分钟/工单→即时 |
-| 18 | AI知识库构建 | 客服 | 2天→1小时 |
-| 19 | AI多语言客服 | 客服 | 5个翻译→1个AI |
-| 20 | AI VIP升级 | 客服 | 30%遗漏→0% |
-| 21 | AI简历筛选 | HR | 3天→2小时 |
-| 22 | AI JD撰写 | HR | 2小时→10分钟 |
-| 23 | AI面试排期 | HR | 45分钟→3分钟 |
-| 24 | AI入职助手 | HR | 2周→3天 |
-| 25 | AI费用审核 | 财务 | 20分钟/份→即时 |
-| 26 | AI财务报告 | 财务 | 2天→3小时 |
-| 27 | AI发票处理 | 财务 | 15分钟/张→30秒 |
-| 28 | AI会议纪要 | 运营 | 30分钟→即时 |
-| 29 | AI库存预测 | 运营 | 每周→实时 |
-| 30 | AI供应商评估 | 运营 | 1周→2小时 |
-| 31 | AI代码迁移 | 研发 | 2周→4小时 |
-| 32 | AI性能分析 | 研发 | 3天→30分钟 |
-| 33 | AI安全扫描 | DevOps | 每周→持续 |
-| 34 | AI数据库优化 | 研发 | 8小时→20分钟 |
-| 35 | AI依赖管理 | 研发 | 4小时/周→10分钟 |
-| 36 | AI品牌监控 | 营销 | 3小时/天→实时 |
-| 37 | AI KOL发现 | 营销 | 2周→2小时 |
-| 38 | AI活动分析 | 营销 | 1天→15分钟 |
-| 39 | AI内容日历 | 营销 | 4小时/周→20分钟 |
-| 40 | AI用户画像 | 营销 | 1周→1小时 |
-| 41 | AI销售预测 | 销售 | 2天→30分钟 |
-| 42 | AI Demo个性化 | 销售 | 3小时→15分钟 |
-| 43 | AI定价优化 | 运营 | 1周→2小时 |
-| 44 | AI合同分析 | 运营 | 4小时/份→10分钟 |
-| 45 | AI流失预测 | 客服 | 每月→实时 |
-| 46 | AI Chatbot训练 | 客服 | 2周→3小时 |
-| 47 | AI Bug优先级 | 研发 | 2小时/天→即时 |
-| 48 | AI SLA跟踪 | 运营 | 手动→自动 |
-| 49 | AI情感分析 | 产品 | 1天→10分钟 |
-| 50 | AI FAQ生成 | 客服 | 3天→2小时 |
-| 51 | AI员工脉搏 | HR | 每月→每周 |
-| 52 | AI培训推荐 | HR | 1周→1小时 |
-| 53 | AI薪酬对标 | HR | 2周→3小时 |
-| 54 | AI绩效撰写 | HR | 2小时/份→15分钟 |
-| 55 | AI政策更新 | 运营 | 2天→3小时 |
-| 56 | AI现金流预测 | 财务 | 1天→30分钟 |
-| 57 | AI合规检查 | 运营 | 1周→4小时 |
-| 58 | AI流程挖掘 | 运营 | 3周→2天 |
-| 59 | AI文档分类 | 运营 | 5分钟/份→即时 |
-| 60 | AI风险评分 | 运营 | 2天→2小时 |
+| 1 | [AI代码审查](/zh/use-cases/role/product-dev#_1-ai代码审查) | 研发 | 4小时→15分钟/PR |
+| 2 | [AI测试生成](/zh/use-cases/role/product-dev#_2-ai测试生成) | 研发/QA | 2天→30分钟 |
+| 3 | [AI部署监控](/zh/use-cases/role/product-dev#_3-ai部署监控) | DevOps | 手动→自动(2分钟MTTR) |
+| 4 | [AI API文档编写](/zh/use-cases/role/product-dev#_4-ai-api文档编写) | 研发 | 1周→2小时 |
+| 5 | [AI调试助手](/zh/use-cases/role/product-dev#_5-ai调试助手) | 研发 | 2小时→10分钟 |
+| 6 | [AI SEO内容写作](/zh/use-cases/role/content-marketing#_1-ai-seo内容写作) | 营销 | 4小时→20分钟/篇 |
+| 7 | [AI社媒管理](/zh/use-cases/role/content-marketing#_2-ai社媒管理) | 营销 | 3小时/天→15分钟 |
+| 8 | [AI广告文案生成](/zh/use-cases/role/content-marketing#_3-ai广告文案生成) | 营销 | 50→200变体/10分钟 |
+| 9 | [AI简报策展](/zh/use-cases/role/content-marketing#_4-ai简报策展) | 营销 | 5小时/周→30分钟 |
+| 10 | [AI竞品文案分析](/zh/use-cases/role/content-marketing#_5-ai竞品文案分析) | 营销 | 2天→1小时 |
+| 11 | [AI线索调研](/zh/use-cases/role/sales#_1-ai线索调研) | 销售 | 20→200线索/天 |
+| 12 | [AI CRM管家](/zh/use-cases/role/sales#_2-ai-crm管家) | 销售 | 45分钟/天→0 |
+| 13 | [AI方案生成](/zh/use-cases/role/sales#_3-ai方案生成) | 销售 | 3小时→15分钟 |
+| 14 | [AI跟进邮件](/zh/use-cases/role/sales#_4-ai跟进邮件) | 销售 | 30分钟→2分钟 |
+| 15 | [AI客户调研简报](/zh/use-cases/role/sales#_5-ai客户调研简报) | 销售 | 1小时→5分钟 |
+| 16 | [AI报价计算](/zh/use-cases/role/sales#_6-ai报价计算) | 销售 | 2小时→10分钟 |
+| 17 | [AI工单分类](/zh/use-cases/role/customer-support#_1-ai工单分类) | 客服 | 5分钟/工单→即时 |
+| 18 | [AI知识库构建](/zh/use-cases/role/customer-support#_2-ai知识库构建) | 客服 | 2天→1小时 |
+| 19 | [AI多语言客服](/zh/use-cases/role/customer-support#_3-ai多语言客服) | 客服 | 5个翻译→1个AI |
+| 20 | [AI VIP升级管理](/zh/use-cases/role/customer-support#_4-ai-vip升级管理) | 客服 | 30%遗漏→0% |
+| 21 | [AI简历筛选](/zh/use-cases/role/hr-recruiting#_1-ai简历筛选) | HR | 3天→2小时 |
+| 22 | [AI职位描述编写](/zh/use-cases/role/hr-recruiting#_2-ai职位描述编写) | HR | 2小时→10分钟 |
+| 23 | [AI面试排期](/zh/use-cases/role/hr-recruiting#_3-ai面试排期) | HR | 45分钟→3分钟 |
+| 24 | [AI入职助手](/zh/use-cases/role/hr-recruiting#_4-ai入职助手) | HR | 2周→3天 |
+| 25 | [AI费用审计](/zh/use-cases/role/finance#_1-ai费用审计) | 财务 | 20分钟/份→即时 |
+| 26 | [AI财务报告生成](/zh/use-cases/role/finance#_2-ai财务报告生成) | 财务 | 2天→3小时 |
+| 27 | [AI发票处理](/zh/use-cases/role/finance#_3-ai发票处理) | 财务 | 15分钟/张→30秒 |
+| 28 | [AI会议纪要](/zh/use-cases/role/operations#_1-ai会议纪要) | 运营 | 30分钟→即时 |
+| 29 | [AI库存预测](/zh/use-cases/role/operations#_2-ai库存预测) | 运营 | 每周→实时 |
+| 30 | [AI供应商评估](/zh/use-cases/role/operations#_3-ai供应商评估) | 运营 | 1周→2小时 |
+| 31 | [AI代码迁移](/zh/use-cases/role/product-dev#_6-ai代码迁移) | 研发 | 2周→4小时 |
+| 32 | [AI性能分析](/zh/use-cases/role/product-dev#_7-ai性能分析) | 研发 | 3天→30分钟 |
+| 33 | [AI安全扫描](/zh/use-cases/role/product-dev#_8-ai安全扫描) | DevOps | 每周→持续 |
+| 34 | [AI数据库优化](/zh/use-cases/role/product-dev#_9-ai数据库优化) | 研发 | 8小时→20分钟 |
+| 35 | [AI依赖管理](/zh/use-cases/role/product-dev#_10-ai依赖管理) | 研发 | 4小时/周→10分钟 |
+| 36 | [AI品牌监测](/zh/use-cases/role/content-marketing#_6-ai品牌监测) | 营销 | 3小时/天→实时 |
+| 37 | [AI达人发现](/zh/use-cases/role/content-marketing#_7-ai达人发现) | 营销 | 2周→2小时 |
+| 38 | [AI营销分析](/zh/use-cases/role/content-marketing#_8-ai营销分析) | 营销 | 1天→15分钟 |
+| 39 | [AI内容日历](/zh/use-cases/role/content-marketing#_9-ai内容日历) | 营销 | 4小时/周→20分钟 |
+| 40 | [AI用户画像](/zh/use-cases/role/content-marketing#_10-ai用户画像) | 营销 | 1周→1小时 |
+| 41 | [AI销售预测](/zh/use-cases/role/sales#_7-ai销售预测) | 销售 | 2天→30分钟 |
+| 42 | [AI演示定制](/zh/use-cases/role/sales#_8-ai演示定制) | 销售 | 3小时→15分钟 |
+| 43 | [AI定价优化](/zh/use-cases/role/operations#_4-ai定价优化) | 运营 | 1周→2小时 |
+| 44 | [AI合同分析](/zh/use-cases/role/operations#_5-ai合同分析) | 运营 | 4小时/份→10分钟 |
+| 45 | [AI流失预测](/zh/use-cases/role/customer-support#_5-ai流失预测) | 客服 | 每月→实时 |
+| 46 | [AI客服机器人训练](/zh/use-cases/role/customer-support#_6-ai客服机器人训练) | 客服 | 2周→3小时 |
+| 47 | [AI缺陷排序](/zh/use-cases/role/product-dev#_11-ai缺陷排序) | 研发 | 2小时/天→即时 |
+| 48 | [AI SLA跟踪](/zh/use-cases/role/operations#_6-ai-sla跟踪) | 运营 | 手动→自动 |
+| 49 | [AI情感分析](/zh/use-cases/role/product-dev#_12-ai情感分析) | 产品 | 1天→10分钟 |
+| 50 | [AI FAQ生成](/zh/use-cases/role/customer-support#_7-ai-faq生成) | 客服 | 3天→2小时 |
+| 51 | [AI员工脉搏](/zh/use-cases/role/hr-recruiting#_5-ai员工脉搏) | HR | 每月→每周 |
+| 52 | [AI培训推荐](/zh/use-cases/role/hr-recruiting#_6-ai培训推荐) | HR | 1周→1小时 |
+| 53 | [AI薪酬对标](/zh/use-cases/role/hr-recruiting#_7-ai薪酬对标) | HR | 2周→3小时 |
+| 54 | [AI绩效评审](/zh/use-cases/role/hr-recruiting#_8-ai绩效评审) | HR | 2小时/份→15分钟 |
+| 55 | [AI政策更新](/zh/use-cases/role/operations#_7-ai政策更新) | 运营 | 2天→3小时 |
+| 56 | [AI现金流预测](/zh/use-cases/role/finance#_4-ai现金流预测) | 财务 | 1天→30分钟 |
+| 57 | [AI合规检查](/zh/use-cases/role/finance#_5-ai合规检查) | 运营 | 1周→4小时 |
+| 58 | [AI流程挖掘](/zh/use-cases/role/operations#_8-ai流程挖掘) | 运营 | 3周→2天 |
+| 59 | [AI文档分类](/zh/use-cases/role/operations#_9-ai文档分类) | 运营 | 5分钟/份→即时 |
+| 60 | [AI风险评分](/zh/use-cases/role/operations#_10-ai风险评分) | 运营 | 2天→2小时 |


### PR DESCRIPTION
## Summary
- All 60 use cases in the "All Use Cases at a Glance" table now have clickable links with precise anchor jumps
- Clicking any use case name jumps directly to its heading on the corresponding role page
- Fixed 19 CN table names to match page heading text for correct anchoring
- Both EN and CN index pages updated

## Changes
- `docs/use-cases/index.md` - 60 EN links with #anchor
- `docs/zh/use-cases/index.md` - 60 CN links with #anchor + 19 name fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)