### PR TITLE
Fix role table order to match sidebar

### DIFF
--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -9,12 +9,12 @@ Find use cases for your specific job function:
 | Role | Cases | Key Scenarios |
 |------|-------|--------------|
 | [Product / Dev](/use-cases/role/product-dev) | 26 | Code Review, Test Gen, API Docs, Security Scanner, ... |
+| [Operations](/use-cases/role/operations) | 36 | Meeting Notes, Inventory Forecasting, Vendor Evaluation, ... |
+| [Finance](/use-cases/role/finance) | 19 | Expense Auditing, Financial Reports, Invoice Processing, ... |
 | [Content / Marketing](/use-cases/role/content-marketing) | 23 | SEO Writing, Social Media, Ad Copy, Brand Monitor, ... |
-| [Sales](/use-cases/role/sales) | 24 | Lead Research, CRM Updates, Proposals, Sales Forecaster, ... |
 | [Customer Support](/use-cases/role/customer-support) | 14 | Ticket Classification, Knowledge Base, Multi-language, ... |
 | [HR / Recruiting](/use-cases/role/hr-recruiting) | 11 | Resume Screening, JD Writing, Interview Scheduling, ... |
-| [Finance](/use-cases/role/finance) | 19 | Expense Auditing, Financial Reports, Invoice Processing, ... |
-| [Operations](/use-cases/role/operations) | 36 | Meeting Notes, Inventory Forecasting, Vendor Evaluation, ... |
+| [Sales](/use-cases/role/sales) | 24 | Lead Research, CRM Updates, Proposals, Sales Forecaster, ... |
 | [Legal](/use-cases/role/legal) | 9 | Contract Analyzer, NDA Generator, IP Portfolio Analyzer, ... |
 | [Executive](/use-cases/role/executive) | 4 | Executive Briefing Generator, Annual Report Assembler, OKR Progress Tracker, ... |
 | [Data Analyst](/use-cases/role/data-analyst) | 14 | Property Valuation Assistant, Crop Yield Predictor, Script Coverage Reader, ... |

--- a/docs/zh/use-cases/index.md
+++ b/docs/zh/use-cases/index.md
@@ -9,12 +9,12 @@
 | 角色 | 数量 | 核心场景 |
 |------|------|---------|
 | [产品/研发](/zh/use-cases/role/product-dev) | 26 | 代码审查、测试生成、API文档、安全扫描... |
+| [运营](/zh/use-cases/role/operations) | 36 | 会议纪要、库存预测、供应商评估... |
+| [财务](/zh/use-cases/role/finance) | 19 | 费用审核、财务报告、发票处理... |
 | [内容/营销](/zh/use-cases/role/content-marketing) | 23 | SEO写作、社媒管理、广告文案、品牌监控... |
-| [销售](/zh/use-cases/role/sales) | 24 | 线索挖掘、CRM更新、方案生成、销售预测... |
 | [客服](/zh/use-cases/role/customer-support) | 14 | 工单分类、知识库、多语言客服... |
 | [HR/招聘](/zh/use-cases/role/hr-recruiting) | 11 | 简历筛选、JD撰写、面试排期、入职助手... |
-| [财务](/zh/use-cases/role/finance) | 19 | 费用审核、财务报告、发票处理... |
-| [运营](/zh/use-cases/role/operations) | 36 | 会议纪要、库存预测、供应商评估... |
+| [销售](/zh/use-cases/role/sales) | 24 | 线索挖掘、CRM更新、方案生成、销售预测... |
 | [法律](/zh/use-cases/role/legal) | 9 | AI合同分析师、AI保密协议生成器、AI知识产权组合分析器... |
 | [高管](/zh/use-cases/role/executive) | 4 | AI高管简报生成器、AI年度报告汇编器、AI OKR进度追踪器... |
 | [数据分析师](/zh/use-cases/role/data-analyst) | 14 | AI房产估值助手、AI作物产量预测器、AI剧本评审阅读器... |


### PR DESCRIPTION
## Summary
- Reorder "Browse by Role" table rows in both EN and ZH index pages to match sidebar navigation order
- Sidebar: Product/Dev → Operations → Finance → Content/Marketing → ...
- Table was: Product/Dev → Content/Marketing → Sales → Customer Support → ...

## Changes
- `docs/use-cases/index.md` - EN role table reordered
- `docs/zh/use-cases/index.md` - ZH role table reordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)