### PR TITLE
fix: zh search UI — 搜索框显示中文

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -274,7 +274,28 @@ export default defineConfig({
     },
 
     search: {
-      provider: 'local'
+      provider: 'local',
+      options: {
+        locales: {
+          zh: {
+            translations: {
+              button: {
+                buttonText: '搜索',
+                buttonAriaLabel: '搜索文档'
+              },
+              modal: {
+                noResultsText: '无法找到相关结果',
+                resetButtonTitle: '清除查询条件',
+                footer: {
+                  selectText: '选择',
+                  navigateText: '切换',
+                  closeText: '关闭'
+                }
+              }
+            }
+          }
+        }
+      }
     },
 
     editLink: {


### PR DESCRIPTION
## Summary
- 中文版搜索框文字从 "Search" 改为 "搜索"（含按钮文字和 aria-label）
- 同步汉化搜索弹框其他 UI（无结果提示、清除按钮、底部快捷键说明）
- 使用 VitePress local search 的 `locales.zh.translations` 配置，不影响英文版

## Test plan
- [ ] 切换到 zh 站点（`/zh/`），点击搜索按钮，确认显示"搜索"
- [ ] 搜索无结果时，确认显示"无法找到相关结果"

Reported by: charlie.hu
🤖 Generated with [Claude Code](https://claude.com/claude-code)