### PR TITLE
fix: translate video fold label to Chinese in ZH pages

### DIFF
--- a/docs/zh/use-cases/industry/agriculture.md
+++ b/docs/zh/use-cases/industry/agriculture.md
@@ -6,7 +6,7 @@ AI驱动的农业行业用例。
 
 > 结合气象数据、土壤报告和历史产量，以8%以内的误差预测收获量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/115-ai-crop-yield-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI作物产量预测器直接集成到你现有的工作流程中，充�
 
 > 结合土壤湿度传感器、天气预报和作物需求——优化灌溉计划，减少30%用水量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/130-ai-irrigation-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI灌溉调度器直接集成到你现有的工作流程中，充当一�
 
 > 分析作物照片和本地病虫害数据库——以95%准确率识别虫害并推荐治疗方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/145-ai-pest-detection-advisor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI病虫害检测顾问直接集成到你现有的工作流程中，充�
 
 > 解读50个田区的pH值、营养和有机质化验结果——推荐施肥方案及成本估算。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/177-ai-soil-health-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI土壤健康报告器直接集成到你现有的工作流程中，充�
 
 > 追踪1000头牲畜的采食量、运动和体温——在可见症状出现前48小时检测疾病指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/192-ai-livestock-health-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/automotive.md
+++ b/docs/zh/use-cases/industry/automotive.md
@@ -6,7 +6,7 @@ AI驱动的汽车行业用例。
 
 > 每日扫描NHTSA数据库和服务公告——将召回信息匹配车队库存并生成行动方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/120-ai-vehicle-recall-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI车辆召回监控器直接集成到你现有的工作流程中，充�
 
 > 将客户偏好与15家经销商库存匹配——推荐最佳车型并估算置换价格。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/135-ai-dealership-inventory-matcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI经销商库存匹配器直接集成到你现有的工作流程中，�
 
 > 跨3个系统同步OEM零件编号、定价和适配数据——每晚核对保持8万SKU准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/150-ai-parts-catalog-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI零件目录更新器直接集成到你现有的工作流程中，充�
 
 > 处理500辆车的GPS、油耗和驾驶行为数据——生成周度评分卡，发现每年$8万节油机会。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/182-ai-fleet-telematics-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI车队远程信息分析器直接集成到你现有的工作流程中�
 
 > 筛选在线潜客、匹配车型偏好并预约试驾——以确认预约填满90%可用时段。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/197-ai-test-drive-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/consulting.md
+++ b/docs/zh/use-cases/industry/consulting.md
@@ -6,7 +6,7 @@ AI驱动的咨询行业用例。
 
 > 15分钟将市场数据、财务信息和竞争情报综合成10页战略简报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/112-ai-strategy-brief-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI战略简报撰写器直接集成到你现有的工作流程中，充�
 
 > 将原始分析转化为麦肯锡风格幻灯片——25分钟构建30张包含图表、关键发现和建议的PPT。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/142-ai-management-consulting-deck-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI咨询方案构建器直接集成到你现有的工作流程中，充�
 
 > 收集50+同行运营KPI——排名客户绩效并识别达到上四分位的改进目标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/157-ai-benchmarking-analyst.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI对标分析师直接集成到你现有的工作流程中，充当一�
 
 > 基于公开数据构建TAM/SAM/SOM模型——20分钟生成自下而上和自上而下的估算及数据来源。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/174-ai-market-sizing-modeler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/ecommerce.md
+++ b/docs/zh/use-cases/industry/ecommerce.md
@@ -6,7 +6,7 @@ AI驱动的电商平台、零售运营和在线市场用例。
 
 > 20分钟产出一篇SEO优化的高质量文章，关键词研究到终稿一站式完成。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/010-ai-seo-content-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -211,7 +211,7 @@ COCO的AI SEO Content Writer将内容创作流水线从一个串行的、劳动�
 
 > 一次输入，全平台适配发布。每天3小时社媒运营缩减到15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/011-ai-social-media-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -398,7 +398,7 @@ COCO的AI Social Media Manager作为社交媒体团队的力量倍增器，处�
 
 > 10分钟生成200个A/B变体广告文案，数据驱动迭代优化。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/012-ai-ad-copy-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -607,7 +607,7 @@ COCO的AI Ad Copy Generator专为效果营销构建，理解各平台付费广�
 
 > 实时追踪竞品动态，2天调研变为1小时自动化输出。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/014-ai-competitive-copywriter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -782,7 +782,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 10分钟完成复杂报价计算，自动匹配折扣规则和审批流程。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/020-ai-quote-calculator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -945,7 +945,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 工单自动分类路由，5分钟/单变为即时处理。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/021-ai-ticket-classifier.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1100,7 +1100,7 @@ SLA层级：[按优先级列出你的SLA要求]
 
 > AI一键支持15+语言客服，替代5个翻译人员。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/023-ai-multi-language-support.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1260,7 +1260,7 @@ COCO的AI Multi-Language Support提供母语质量的多语言客户服务，无
 
 > 自动识别VIP客户异常，30%漏检降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/024-ai-vip-escalation.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1417,7 +1417,7 @@ CSM：[姓名]
 
 > 30秒处理一张发票：提取、匹配、路由全自动。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/031-ai-invoice-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1584,7 +1584,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 实时库存预测，替代每周手动盘点，减少滞销和缺货。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/033-ai-inventory-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1742,7 +1742,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 品牌危机发现时间从72小时降至11分钟，覆盖率从10%到97%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/040-ai-brand-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1848,7 +1848,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 达人审核从15小时降至20分钟，投放ROI从0.8倍提升到4.2倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/041-ai-influencer-finder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1954,7 +1954,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 统一6渠道23个活动的归因分析，ROAS提升37%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/042-ai-campaign-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2060,7 +2060,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 内容规划从每周8小时降至45分钟，发布一致性从62%到96%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/043-ai-content-calendar.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2166,7 +2166,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 用户画像创建从6周缩短到2天，细分准确度89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/044-ai-persona-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2272,7 +2272,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 实时竞品定价监控，响应时间从3周到4小时，用户收入+23%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/047-ai-pricing-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2378,7 +2378,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 客服机器人解决率从27%提至78%，训练时间从6个月到2周。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/050-ai-chatbot-trainer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2484,7 +2484,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 工单分流+45%，FAQ覆盖从120篇到850+篇，每周节省23小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/054-ai-faq-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2590,7 +2590,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 数据录入自动化，准确率从96%提升至99.7%，处理时间减少94%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/065-ai-data-entry-automator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2777,7 +2777,7 @@ COCO的AI数据录入自动化工具连接你现有的文档来源和目标系�
 
 > 产品反馈分析从2周缩短到2小时，覆盖100%的用户反馈。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/070-ai-product-feedback-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2956,7 +2956,7 @@ COCO的AI产品反馈分析器将这种混乱转变为流畅的智能工作流�
 
 > 销售区域平衡度提升45%，区域间业绩差距缩小60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/073-ai-sales-territory-mapper.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3135,7 +3135,7 @@ COCO的AI销售区域规划器将这种混乱转变为流畅的智能工作流�
 
 > 本地化周期从6周缩短到3天，翻译一致性提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/076-ai-localization-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3314,7 +3314,7 @@ COCO的AI本地化管理器将这种混乱转变为流畅的智能工作流。�
 
 > 供应链可视性从30%提升到95%，中断响应时间减少76%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/077-ai-supply-chain-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3493,7 +3493,7 @@ COCO的AI供应链追踪器将这种混乱转变为流畅的智能工作流。�
 
 > 营销ROI报告生成从3天降至实时，跨渠道归因准确率92%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/079-ai-marketing-roi-dashboard.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3672,7 +3672,7 @@ COCO的AI营销ROI仪表盘将这种混乱转变为流畅的智能工作流。�
 
 > 流失客户挽回率从8%提升到35%，获客成本降低60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/086-ai-customer-win-back-campaigner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3851,7 +3851,7 @@ COCO的AI客户挽回营销器将这种混乱转变为流畅的智能工作流�
 
 > 发票核对时间减少85%，差异检出率从72%提升到99.5%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/088-ai-vendor-invoice-reconciler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4030,7 +4030,7 @@ COCO的AI供应商发票核对器将这种混乱转变为流畅的智能工作�
 
 > 品牌提及监测覆盖率从15%提升到96%，危机响应时间降至15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/089-ai-social-listening-agent.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4229,7 +4229,7 @@ COCO的AI社交媒体监听助手作为7×24小时品牌情报系统运作，覆
 
 > 调研回复率从3%提升到28%，可操作洞察产出量增加5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/094-ai-customer-survey-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4474,7 +4474,7 @@ COCO的AI客户调研设计师将调查从粗糙的工具转变为精准的反�
 
 > 需求预测误差从35%降至8%，库存成本降低28%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/100-ai-demand-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4674,7 +4674,7 @@ COCO的AI需求预测器通过结合先进的机器学习和外部信号集成�
 
 > 跨5家承运商追踪每日2000次配送——自动就延误联系客户并建议重新配送时间。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/165-ai-last-mile-delivery-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/education.md
+++ b/docs/zh/use-cases/industry/education.md
@@ -6,7 +6,7 @@ AI驱动的教育行业用例。
 
 > 10分钟内生成12周课程大纲——包含学习目标、作业设计和评分标准。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/107-ai-curriculum-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI课程设计师直接集成到你现有的工作流程中，充当一�
 
 > 汇总200名学生的成绩、出勤和参与数据——每周标记高风险学生并建议干预措施。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/122-ai-student-progress-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI学生进度追踪器直接集成到你现有的工作流程中，充�
 
 > 将学生提交内容与1000万+来源和AI生成模式对比——标记可疑段落并给出置信度评分。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/137-ai-plagiarism-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI抄袭检测器直接集成到你现有的工作流程中，充当一�
 
 > 将课程项目与150+认证标准对照——突出差距并自动生成证据文档。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/152-ai-accreditation-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI认证合规检查器直接集成到你现有的工作流程中，充�
 
 > 按评分标准批改研究论文——2分钟提供论证、证据和写作质量的段落级反馈。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/163-ai-research-paper-grader.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI论文评分助手直接集成到你现有的工作流程中，充当�
 
 > 通过诊断测验评估学生技能——生成个性化8周学习路径，含资源、里程碑和检查点。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/169-ai-learning-path-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI学习路径构建器直接集成到你现有的工作流程中，充�
 
 > 建模人口趋势、申请漏斗和竞争动态——以3%以内误差预测下一年招生人数。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/184-ai-enrollment-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/energy.md
+++ b/docs/zh/use-cases/industry/energy.md
@@ -6,7 +6,7 @@ AI驱动的能源行业用例。
 
 > 关联1000+电网节点传感器数据——2分钟定位故障根因，替代原来的2小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/116-ai-grid-outage-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI电网故障分析器直接集成到你现有的工作流程中，充�
 
 > 从12个数据源汇总范围1-3排放数据——生成符合GHG协议的审计就绪碳排放报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/131-ai-carbon-footprint-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI碳足迹报告生成器直接集成到你现有的工作流程中，�
 
 > 实时追踪2000+太阳能板产出——10分钟内检测衰减、遮挡问题和逆变器故障。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/146-ai-solar-panel-performance-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI太阳能板性能监控器直接集成到你现有的工作流程中�
 
 > 监控现货价格、天气预报和需求曲线——建议次日能源市场的最优买卖时间窗口。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/178-ai-energy-trading-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI能源交易助手直接集成到你现有的工作流程中，充当�
 
 > 审查80页购电协议——10分钟标记价格升级条款、限电风险和不利条款。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/193-ai-power-purchase-agreement-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/enterprise.md
+++ b/docs/zh/use-cases/industry/enterprise.md
@@ -6,7 +6,7 @@ AI驱动的企业行业用例。
 
 > 3分钟扫描50页合同——签字前标记风险条款、缺失条款和异常条件。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/105-ai-contract-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI合同分析师直接集成到你现有的工作流程中，充当一�
 
 > 搜索USPTO、EUIPO等20+商标数据库——10分钟交付带风险评分的全面冲突报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/153-ai-trademark-conflict-searcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI商标冲突检索器直接集成到你现有的工作流程中，充�
 
 > 将6个部门数据综合为2页周一晨报——KPI、风险、待决事项，仅需5分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/167-ai-executive-briefing-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI高管简报生成器直接集成到你现有的工作流程中，充�
 
 > 识别保管人、发送保全通知、追踪确认并监控合规——管理50+活跃保全，零遗漏截止日期。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/170-ai-litigation-hold-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI诉讼保全管理器直接集成到你现有的工作流程中，充�
 
 > 从10个部门收集ESG指标——2小时内起草符合TCFD和GRI标准的披露文件并验证数据。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/185-ai-esg-disclosure-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI ESG披露撰写器直接集成到你现有的工作流程中，充当�
 
 > 从Jira、Salesforce等6个工具同步关键结果——生成周度OKR评分卡显示红黄绿状态。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/200-ai-okr-progress-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI OKR进度追踪器直接集成到你现有的工作流程中，充当�
 
 > 从8个部门更新汇编董事会资料包——将财务、战略和表决事项格式化为品牌化40页PPT。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/203-ai-board-meeting-prep-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/financial-services.md
+++ b/docs/zh/use-cases/industry/financial-services.md
@@ -6,7 +6,7 @@ AI驱动的银行、保险、投资和金融机构用例。
 
 > 一天调研200个线索，自动从LinkedIn、企查查抓取并打分。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/015-ai-lead-researcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -190,7 +190,7 @@ LinkedIn URL：[URL]
 
 > 8分钟生成客户会议简报，多源情报汇聚，高管画像深入。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/019-ai-client-research-brief.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -340,7 +340,7 @@ COCO的AI Client Research Brief在几分钟内为每次客户会议提供全面�
 
 > 自动识别VIP客户异常，30%漏检降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/024-ai-vip-escalation.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -497,7 +497,7 @@ CSM：[姓名]
 
 > 费用报告即时审核，合规自动通过，异常自动标记。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/029-ai-expense-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -653,7 +653,7 @@ COCO的AI Expense Auditor提供100%的审计覆盖和一致的政策执行。
 
 > 3小时生成多源数据对账的财务报告，替代2天人工。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/030-ai-financial-report-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -791,7 +791,7 @@ COCO的AI Financial Report Generator自动化数据组装、计算和叙事生�
 
 > 30秒处理一张发票：提取、匹配、路由全自动。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/031-ai-invoice-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -958,7 +958,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 230万行遗留代码迁移从8年缩短到14个月，缺陷率从23%降至3%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/035-ai-code-migrator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1064,7 +1064,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 销售预测误差从40%降至8%，成交预测91%准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/045-ai-sales-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1170,7 +1170,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 合同审查从5天降至45分钟，风险检出率从72%提至99%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/048-ai-contract-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1276,7 +1276,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 847份政策文档更新从6周缩短到4天，合规风险降89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/059-ai-policy-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1382,7 +1382,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 现金流预测准确率从64%提至93%，全年零现金危机。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/060-ai-cash-flow-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1488,7 +1488,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 交易合规检查覆盖率从5%到100%，审计准备从6周到3天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/061-ai-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1594,7 +1594,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 流程时间从14天降至4天，返工率从31%降至8%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/062-ai-process-miner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1700,7 +1700,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 风险预测84%准确，每年预防$420万损失。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/064-ai-risk-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1806,7 +1806,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 法律文档起草从5天缩短到2小时，合规风险降低85%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/068-ai-legal-document-drafter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1985,7 +1985,7 @@ COCO的AI法律文档起草助手将这种混乱转变为流畅的智能工作�
 
 > 监管申报准备时间减少78%，合规错误降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/071-ai-regulatory-filing-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2164,7 +2164,7 @@ COCO的AI合规申报助手将这种混乱转变为流畅的智能工作流。�
 
 > 数据管道故障检测从小时级降至秒级，数据质量问题减少91%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/075-ai-data-pipeline-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2343,7 +2343,7 @@ COCO的AI数据管道监控器将这种混乱转变为流畅的智能工作流�
 
 > 事件响应时间从45分钟降至8分钟，MTTR减少73%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/080-ai-incident-response-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2522,7 +2522,7 @@ COCO的AI事件响应协调器将这种混乱转变为流畅的智能工作流�
 
 > 税务准备时间减少70%，申报错误降低92%，罚款归零。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/085-ai-tax-preparation-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2701,7 +2701,7 @@ COCO的AI税务准备助手将这种混乱转变为流畅的智能工作流。�
 
 > 发票核对时间减少85%，差异检出率从72%提升到99.5%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/088-ai-vendor-invoice-reconciler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2880,7 +2880,7 @@ COCO的AI供应商发票核对器将这种混乱转变为流畅的智能工作�
 
 > 租赁合同审查从5天降至1小时，隐藏条款识别率提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/091-ai-lease-agreement-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3068,7 +3068,7 @@ COCO的AI租赁合同审查师充当你不知疲倦的租赁分析师，结合�
 
 > 董事会报告编制从40小时降至4小时，数据准确率达99.8%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/096-ai-board-report-compiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3285,7 +3285,7 @@ KPI数据（本季度 vs 上季度 vs 计划）：
 
 > 合规培训完成率从52%提升到96%，逾期培训降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/097-ai-compliance-training-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3508,7 +3508,7 @@ COCO的AI合规培训追踪器将合规培训从被动、人力密集的流程�
 
 > 提取公开文件、新闻、诉讼记录和财务数据——2小时完成尽职调查报告，替代原来的2周。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/127-ai-due-diligence-compiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3632,7 +3632,7 @@ COCO的AI尽职调查编撰器直接集成到你现有的工作流程中，充�
 
 > 每日监控SEC、FINRA和12个全球监管机构——将新规映射到合规义务，提前48小时预警。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/164-ai-regulatory-change-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/government.md
+++ b/docs/zh/use-cases/industry/government.md
@@ -6,7 +6,7 @@ AI驱动的政府行业用例。
 
 > 跨部门追踪200+许可证申请——提前7天标记缺失文件和临近截止日期。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/114-ai-permit-application-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI许可证申请追踪器直接集成到你现有的工作流程中，�
 
 > 同时搜索15个政府数据库——5分钟编撰房产、法院和商业记录。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/129-ai-public-records-researcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI公共记录研究员直接集成到你现有的工作流程中，充�
 
 > 处理市政厅和调查中的1万+市民评论——将主题、情绪和紧急程度聚类为可操作简报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/144-ai-constituent-feedback-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI选民反馈分析器直接集成到你现有的工作流程中，充�
 
 > 对照豁免标准审查信息公开请求——编辑敏感内容并起草回复，处理周期从30天缩短到5天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/159-ai-foia-request-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI信息公开请求处理器直接集成到你现有的工作流程中�
 
 > 每月对比200个预算项的实际支出——突出超过5%的差异并提供下钻分析。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/176-ai-budget-variance-analyst.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI预算差异分析师直接集成到你现有的工作流程中，充�
 
 > 按25项加权标准评分30份供应商投标——45分钟生成比较矩阵并筛选前3名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/191-ai-procurement-bid-evaluator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/healthcare.md
+++ b/docs/zh/use-cases/industry/healthcare.md
@@ -6,7 +6,7 @@ AI驱动的医疗健康行业用例。
 
 > 90秒数字化患者入院表——将人口统计、保险信息和病史自动录入电子病历系统。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/106-ai-patient-intake-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI患者入院处理器直接集成到你现有的工作流程中，充�
 
 > 将患者记录与40+试验标准匹配——筛选合格候选人速度比人工快10倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/121-ai-clinical-trial-screener.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI临床试验筛查器直接集成到你现有的工作流程中，充�
 
 > 扫描访问日志、加密配置和数据流——15分钟识别HIPAA违规并生成整改任务。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/136-ai-hipaa-compliance-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI HIPAA合规审计师直接集成到你现有的工作流程中，充�
 
 > 阅读临床记录分配ICD-10和CPT编码——首次准确率96%，拒付率降低40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/151-ai-medical-coding-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI医疗编码助手直接集成到你现有的工作流程中，充当�
 
 > 将20页患者病历浓缩为结构化1页摘要——突出活跃问题、用药和待处理医嘱。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/162-ai-clinical-notes-summarizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI临床笔记摘要器直接集成到你现有的工作流程中，充�
 
 > 映射新旧电子病历系统间的字段——转换50万条患者记录，带验证检查和错误日志。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/168-ai-ehr-data-migrator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI电子病历数据迁移器直接集成到你现有的工作流程中�
 
 > 对比5家PBM的药品目录方案——找到节省22%药品支出的等效替代品，不影响疗效。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/183-ai-pharmacy-benefit-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -874,7 +874,7 @@ COCO的AI药品福利优化器直接集成到你现有的工作流程中，充�
 
 > 绘制200名医师的转诊模式——识别高价值关系缺口和拓展优先级。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/201-ai-referral-network-mapper.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/hospitality.md
+++ b/docs/zh/use-cases/industry/hospitality.md
@@ -6,7 +6,7 @@ AI驱动的酒店/餐饮行业用例。
 
 > 在6个平台上为客人评论撰写个性化回复——每条30秒，完美匹配品牌语调。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/110-ai-hotel-review-responder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI酒店评论回复器直接集成到你现有的工作流程中，充�
 
 > 计算每道菜品的食材成本占比——建议价格调整和替代方案以达到30%毛利目标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/125-ai-menu-cost-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI菜单成本分析器直接集成到你现有的工作流程中，充�
 
 > 分析预订历史和客人画像——推荐个性化房间升级和套餐，RevPAR提升18%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/140-ai-guest-upsell-recommender.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI客人升级推荐器直接集成到你现有的工作流程中，充�
 
 > 协调300人活动的场地、餐饮、音视频和人员——15分钟生成时间线、检查单和供应商订单。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/155-ai-event-logistics-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI活动后勤规划器直接集成到你现有的工作流程中，充�
 
 > 根据退房时间、特殊需求和距离将80间房分配给15名清洁员——周转时间缩短25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/172-ai-housekeeping-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI客房清洁调度器直接集成到你现有的工作流程中，充�
 
 > 基于需求、活动和竞争定价动态调整房价——比静态定价提升12% RevPAR。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/187-ai-revenue-management-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/insurance.md
+++ b/docs/zh/use-cases/industry/insurance.md
@@ -6,7 +6,7 @@ AI驱动的保险行业用例。
 
 > 对照保单条款审核理赔申请——自动通过简单案件，处理时间从5天缩短到4小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/117-ai-claims-adjuster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI理赔评估师直接集成到你现有的工作流程中，充当一�
 
 > 分析理赔历史、风险画像和市场费率——到期前30天推荐最优续保方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/132-ai-policy-renewal-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI保单续保优化器直接集成到你现有的工作流程中，充�
 
 > 对照50项风险因素评估申请人数据——8分钟生成带置信度评分的核保建议。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/147-ai-underwriting-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI核保助手直接集成到你现有的工作流程中，充当一个�
 
 > 分析10万条理赔记录——以92%精度识别可疑聚类和伪造事故指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/179-ai-fraud-pattern-detector.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI欺诈模式检测器直接集成到你现有的工作流程中，充�
 
 > 对保险账簿运行500个死亡率和发病率情景——30分钟压力测试准备金并突出资金不足环节。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/194-ai-actuarial-scenario-runner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/logistics.md
+++ b/docs/zh/use-cases/industry/logistics.md
@@ -6,7 +6,7 @@ AI驱动的物流行业用例。
 
 > 跨承运商监控500+在途货物——在延误影响交付前4小时发出预警。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/109-ai-shipment-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI货运追踪器直接集成到你现有的工作流程中，充当一�
 
 > 分析拣货频率和订单模式——重新设计仓库分区，平均拣货时间缩短35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/124-ai-warehouse-layout-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI仓库布局优化器直接集成到你现有的工作流程中，充�
 
 > 规划每日80个站点的最优配送路线——综合交通、时间窗和车辆容量，燃油成本降低20%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/139-ai-route-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI路线优化器直接集成到你现有的工作流程中，充当一�
 
 > 将运费与200+航线的市场数据对标——发现平均每批货物可节省12%的机会。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/154-ai-freight-rate-negotiator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI运费谈判助手直接集成到你现有的工作流程中，充当�
 
 > 在20个月台协调进出车辆——通过实时时段优化将停留时间缩短45%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/171-ai-cross-dock-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI越库调度器直接集成到你现有的工作流程中，充当一�
 
 > 将货物归入HS编码、计算关税并预填报关单——清关时间从48小时缩短到6小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/186-ai-customs-declaration-filer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/manufacturing.md
+++ b/docs/zh/use-cases/industry/manufacturing.md
@@ -6,7 +6,7 @@ AI驱动的制造业行业用例。
 
 > 分析产线照片和传感器数据——产品出厂前以98.5%准确率捕捉缺陷。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/111-ai-production-defect-detector.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI生产缺陷检测器直接集成到你现有的工作流程中，充�
 
 > 分析100+设备的振动、温度和运行数据——在故障前安排维护，停机时间减少40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/126-ai-predictive-maintenance-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI预测性维护调度器直接集成到你现有的工作流程中，�
 
 > 将BOM与5000+供应商目录交叉验证——3分钟发现停产零件并建议替代方案以降低成本。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/141-ai-bill-of-materials-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI物料清单检查器直接集成到你现有的工作流程中，充�
 
 > 从自然语言中提取事故细节——生成符合OSHA标准的报告，包含根因分析和纠正措施。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/156-ai-safety-incident-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI安全事故报告器直接集成到你现有的工作流程中，充�
 
 > 跨地缘政治、财务和天气风险因素监控300家供应商——每日生成带缓解措施的风险评分卡。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/160-ai-supply-chain-risk-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI供应链风险评分器直接集成到你现有的工作流程中，�
 
 > 排序200个生产订单以最小化换线时间——在满足所有交期的同时提升15%产量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/173-ai-production-batch-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI生产批次优化器直接集成到你现有的工作流程中，充�
 
 > 实时监控50张控制图——在产生废品前3个班次检测到超差趋势，自动触发警报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/188-ai-spc-chart-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/media-entertainment.md
+++ b/docs/zh/use-cases/industry/media-entertainment.md
@@ -6,7 +6,7 @@ AI驱动的媒体/娱乐行业用例。
 
 > 阅读120页剧本生成专业评审——8分钟完成剧情概要、角色分析和市场适配度评估。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/118-ai-script-coverage-reader.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI剧本评审阅读器直接集成到你现有的工作流程中，充�
 
 > 转录60分钟节目，提取关键引用，4分钟生成带时间戳的SEO优化节目笔记。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/133-ai-podcast-show-notes-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI播客节目笔记撰写器直接集成到你现有的工作流程中�
 
 > 处理8个平台的流媒体数据——30分钟按分成协议精确计算5万首曲目的艺人版税。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/148-ai-royalty-calculator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI版税计算器直接集成到你现有的工作流程中，充当一�
 
 > 跨30个地区追踪1万+作品的授权窗口——权利到期前60天提醒续约决策。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/180-ai-content-rights-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI内容版权追踪器直接集成到你现有的工作流程中，充�
 
 > 按观看历史、人口统计和互动数据聚类200万观众——构建12个可操作画像用于定向内容策略。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/195-ai-audience-segmentation-engine.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/nonprofit.md
+++ b/docs/zh/use-cases/industry/nonprofit.md
@@ -6,7 +6,7 @@ AI驱动的非营利行业用例。
 
 > 根据资助方要求撰写拨款申请——20分钟生成预算、时间表和影响力指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/113-ai-grant-proposal-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI拨款申请撰写器直接集成到你现有的工作流程中，充�
 
 > 对5000+捐赠者进行参与度、捐赠历史和能力评分——优先联络以提升续捐率25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/128-ai-donor-engagement-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI捐赠者互动追踪器直接集成到你现有的工作流程中，�
 
 > 根据技能、空闲时间和历史表现将500名志愿者匹配到30个活动岗位——自动发送确认。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/143-ai-volunteer-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI志愿者协调器直接集成到你现有的工作流程中，充当�
 
 > 从8个数据源汇总项目数据——20分钟生成包含可视化和成果指标的资助方报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/158-ai-impact-measurement-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI影响力评估报告器直接集成到你现有的工作流程中，�
 
 > 策划500人晚宴——在一个面板管理RSVP、座位安排、拍卖目录和赞助方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/175-ai-fundraising-event-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI筹款活动策划器直接集成到你现有的工作流程中，充�
 
 > 提取财务、项目成果和捐赠数据——3小时汇编包含图表和叙述的印刷就绪年度报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/190-ai-annual-report-assembler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/real-estate.md
+++ b/docs/zh/use-cases/industry/real-estate.md
@@ -6,7 +6,7 @@ AI驱动的房地产行业用例。
 
 > 提取20+可比房产数据，调整位置和条件因素，5分钟生成市场估值报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/108-ai-property-valuation-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI房产估值助手直接集成到你现有的工作流程中，充当�
 
 > 从上传的平面图提取房间尺寸、计算可用面积并标记违规——仅需2分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/166-ai-floor-plan-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI平面图分析器直接集成到你现有的工作流程中，充当�
 
 > 提取信用、就业和租赁历史——3分钟生成符合公平住房法的带风险评分筛查报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/199-ai-tenant-screening-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI租户筛查处理器直接集成到你现有的工作流程中，充�
 
 > 提取30笔近期成交，调整特征和时间因素——生成含照片和定价依据的客户报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/202-ai-comparative-market-analysis.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/technology.md
+++ b/docs/zh/use-cases/industry/technology.md
@@ -6,7 +6,7 @@ AI驱动的科技公司、SaaS平台和软件开发团队用例。
 
 > 自动审查每个PR：Bug、安全漏洞、性能问题——15分钟出完整报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/005-ai-code-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -146,7 +146,7 @@ PR信息：
 
 > 读取源码，30分钟生成包含边界条件的完整测试。覆盖率从34%提升到89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/006-ai-test-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -322,7 +322,7 @@ Bug描述：[描述bug]
 
 > 实时监控每次部署，90秒检测异常，自动回滚。MTTR从47分钟降至2分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/007-ai-deploy-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -493,7 +493,7 @@ COCO的AI Deploy Monitor作为智能层叠加在你现有的监控基础设施�
 
 > 从代码库自动生成并同步API文档，多语言示例，零偏差。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/008-ai-api-doc-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -678,7 +678,7 @@ API概述：[简要描述API功能]
 
 > 粘贴错误日志，AI从症状追溯到根因，提供可直接应用的修复diff。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/009-ai-debug-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -877,7 +877,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 20分钟产出一篇SEO优化的高质量文章，关键词研究到终稿一站式完成。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/010-ai-seo-content-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1082,7 +1082,7 @@ COCO的AI SEO Content Writer将内容创作流水线从一个串行的、劳动�
 
 > 一次输入，全平台适配发布。每天3小时社媒运营缩减到15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/011-ai-social-media-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1269,7 +1269,7 @@ COCO的AI Social Media Manager作为社交媒体团队的力量倍增器，处�
 
 > 10分钟生成200个A/B变体广告文案，数据驱动迭代优化。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/012-ai-ad-copy-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1478,7 +1478,7 @@ COCO的AI Ad Copy Generator专为效果营销构建，理解各平台付费广�
 
 > 实时追踪竞品动态，2天调研变为1小时自动化输出。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/014-ai-competitive-copywriter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1653,7 +1653,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 一天调研200个线索，自动从LinkedIn、企查查抓取并打分。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/015-ai-lead-researcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1837,7 +1837,7 @@ LinkedIn URL：[URL]
 
 > 通话、邮件、会议自动同步CRM，45分钟/天数据录入变为0。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/016-ai-crm-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1995,7 +1995,7 @@ Pipeline数据：
 
 > 工单自动分类路由，5分钟/单变为即时处理。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/021-ai-ticket-classifier.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2150,7 +2150,7 @@ SLA层级：[按优先级列出你的SLA要求]
 
 > 1小时生成50篇知识库文章，从工单和对话自动提取。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/022-ai-knowledge-base-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2308,7 +2308,7 @@ COCO的AI Knowledge Base Builder将已解决的客服工单转化为已发布的
 
 > AI一键支持15+语言客服，替代5个翻译人员。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/023-ai-multi-language-support.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2468,7 +2468,7 @@ COCO的AI Multi-Language Support提供母语质量的多语言客户服务，无
 
 > 2小时筛选500份简历，替代3天人工筛选。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/025-ai-resume-screener.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2621,7 +2621,7 @@ COCO的AI Resume Screener对每份申请进行深度、一致的分析，对照�
 
 > 10分钟生成无偏见、SEO优化的职位描述。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/026-ai-job-description-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2796,7 +2796,7 @@ COCO的AI Job Description Writer创建引人注目的、包容的、高效的职
 
 > 新员工3天完成入职，替代传统2周流程。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/028-ai-onboarding-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2974,7 +2974,7 @@ COCO的AI Onboarding Assistant协调从offer接受到90天里程碑的整个入�
 
 > 会议结束即出纪要：转录、摘要、待办分配一步到位。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/032-ai-meeting-notes.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3136,7 +3136,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 230万行遗留代码迁移从8年缩短到14个月，缺陷率从23%降至3%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/035-ai-code-migrator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3242,7 +3242,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 页面加载从4.7秒优化到0.9秒，3周诊断时间变4小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/036-ai-performance-profiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3348,7 +3348,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 持续安全扫描，误报率从91%降至8%，修复时间从38天到4天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/037-ai-security-scanner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3454,7 +3454,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 慢查询从12秒优化到0.3秒，云计算成本降低42%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/038-ai-database-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3559,7 +3559,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 自动管理1847个依赖，23个CVE全部清零，更新成功率94%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/039-ai-dependency-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3665,7 +3665,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 客户流失预测87%准确，挽回率从12%提至41%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/049-ai-churn-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3771,7 +3771,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 客服机器人解决率从27%提至78%，训练时间从6个月到2周。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/050-ai-chatbot-trainer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3877,7 +3877,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > Bug分诊从6小时/Sprint降至30分钟，严重Bug修复从14天到3天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/051-ai-bug-prioritizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3983,7 +3983,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 100%处理14000条月度反馈，问题发现从3周到24小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/053-ai-sentiment-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4089,7 +4089,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 员工调查响应率从31%提至82%，离职预测89%准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/055-ai-employee-pulse.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4195,7 +4195,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 实时薪酬对标，Offer竞争力从52%提至89%，遗憾离职降35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/057-ai-comp-benchmarker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4301,7 +4301,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 邮件处理时间减少73%，优先邮件响应从4.2小时降至23分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/066-ai-email-triage-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4472,7 +4472,7 @@ COCO的AI邮件分诊管理器将这种混乱转变为流畅的智能工作流�
 
 > 会议安排后勤时间减少87%，跨时区会议安排速度提升3倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/067-ai-meeting-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4642,7 +4642,7 @@ COCO的AI会议调度助手将这种混乱转变为流畅的智能工作流。�
 
 > 客户流失预警提前30天发现，挽回率从15%提升到42%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/069-ai-customer-success-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4821,7 +4821,7 @@ COCO的AI客户成功监控器将这种混乱转变为流畅的智能工作流�
 
 > 产品反馈分析从2周缩短到2小时，覆盖100%的用户反馈。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/070-ai-product-feedback-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5000,7 +5000,7 @@ COCO的AI产品反馈分析器将这种混乱转变为流畅的智能工作流�
 
 > 项目状态报告编写从4小时降至15分钟，实时数据自动聚合。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/072-ai-project-status-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5179,7 +5179,7 @@ COCO的AI项目状态报告生成器将这种混乱转变为流畅的智能工�
 
 > 工单误路由减少89%，升级解决时间从24小时降至2小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/074-ai-helpdesk-escalation-router.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5358,7 +5358,7 @@ COCO的AI工单升级路由器将这种混乱转变为流畅的智能工作流�
 
 > 数据管道故障检测从小时级降至秒级，数据质量问题减少91%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/075-ai-data-pipeline-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5537,7 +5537,7 @@ COCO的AI数据管道监控器将这种混乱转变为流畅的智能工作流�
 
 > 本地化周期从6周缩短到3天，翻译一致性提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/076-ai-localization-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5716,7 +5716,7 @@ COCO的AI本地化管理器将这种混乱转变为流畅的智能工作流。�
 
 > 客户入驻时间从3周缩短到3天，首月激活率提升55%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/078-ai-customer-onboarding-guide.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5895,7 +5895,7 @@ COCO的AI客户入驻引导助手将这种混乱转变为流畅的智能工作�
 
 > 事件响应时间从45分钟降至8分钟，MTTR减少73%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/080-ai-incident-response-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6074,7 +6074,7 @@ COCO的AI事件响应协调器将这种混乱转变为流畅的智能工作流�
 
 > 专利检索从3周缩短到4小时，现有技术覆盖率从60%提升到97%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/081-ai-patent-research-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6253,7 +6253,7 @@ COCO的AI专利研究助手将这种混乱转变为流畅的智能工作流。�
 
 > 员工离职流程从2周缩短到1天，权限撤销遗漏降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/082-ai-employee-offboarding-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6432,7 +6432,7 @@ COCO的AI员工离职管理器将这种混乱转变为流畅的智能工作流�
 
 > QA覆盖率从40%提升到92%，回归缺陷减少67%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/083-ai-quality-assurance-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6611,7 +6611,7 @@ COCO的AI质量保证审计器将这种混乱转变为流畅的智能工作流�
 
 > 竞品动态检测从每月一次变为实时，战略响应速度提升5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/084-ai-competitive-intelligence-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6790,7 +6790,7 @@ COCO的AI竞争情报追踪器将这种混乱转变为流畅的智能工作流�
 
 > 流失客户挽回率从8%提升到35%，获客成本降低60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/086-ai-customer-win-back-campaigner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6969,7 +6969,7 @@ COCO的AI客户挽回营销器将这种混乱转变为流畅的智能工作流�
 
 > 技术文档编写从3天降至2小时，文档与代码同步率99%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/087-ai-technical-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -7157,7 +7157,7 @@ SDK语言：[语言]
 
 > 品牌提及监测覆盖率从15%提升到96%，危机响应时间降至15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/089-ai-social-listening-agent.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -7356,7 +7356,7 @@ COCO的AI社交媒体监听助手作为7×24小时品牌情报系统运作，覆
 
 > 冲刺规划会议从3小时缩短到45分钟，交付准确率提升38%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/090-ai-sprint-planning-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -7553,7 +7553,7 @@ COCO的AI冲刺规划助手将冲刺规划从主观辩论转变为数据驱动�
 
 > 职位广告点击率提升65%，优质候选人申请量增加40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/093-ai-recruitment-marketing-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -7732,7 +7732,7 @@ COCO的AI招聘营销文案助手将这种混乱转变为流畅的智能工作�
 
 > 调研回复率从3%提升到28%，可操作洞察产出量增加5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/094-ai-customer-survey-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -7977,7 +7977,7 @@ COCO的AI客户调研设计师将调查从粗糙的工具转变为精准的反�
 
 > 发版说明编写从3-4小时降至5分钟，功能采用率提升35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/095-ai-release-notes-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -8241,7 +8241,7 @@ Git日志：
 
 > 合规培训完成率从52%提升到96%，逾期培训降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/097-ai-compliance-training-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -8463,7 +8463,7 @@ COCO的AI合规培训追踪器将合规培训从被动、人力密集的流程�
 
 > 销售异议处理成功率从35%提升到72%，成交周期缩短25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/098-ai-sales-objection-handler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -8695,7 +8695,7 @@ COCO的AI销售异议处理器将经验知识转化为可扩展的、始终最�
 
 > IT资产可见性从45%提升到99%，影子IT发现率提升10倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/099-ai-it-asset-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -8928,7 +8928,7 @@ COCO的AI IT资产管理器为您组织中的每项技术资产创建全面、�
 
 > 演示文稿制作从15小时降至1小时，客户定制度提升300%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/101-ai-pitch-deck-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -9133,7 +9133,7 @@ COCO的AI演示文稿构建器将演示创建从手动、耗时的苦差事转�
 
 > 客户健康度评估覆盖率从20%提升到100%，流失预警准确率87%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/102-ai-customer-health-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -9345,7 +9345,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 跨部门工作流自动化率从15%提升到78%，处理时间减少65%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/103-ai-workflow-automator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -9550,7 +9550,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > RFP响应时间从40小时降至8小时，中标率从5%提升到18%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/104-ai-rfp-response-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -9781,7 +9781,7 @@ RFP表现数据（过去12个月）：
 
 > 60秒生成符合管辖区要求的保密协议——根据交易背景定制范围、期限和例外条款。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/123-ai-nda-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -9905,7 +9905,7 @@ COCO的AI保密协议生成器直接集成到你现有的工作流程中，充�
 
 > 将专利组合与竞争对手申请对比——跨300+专利识别空白领域和潜在侵权风险。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/138-ai-ip-portfolio-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -10029,7 +10029,7 @@ COCO的AI知识产权组合分析器直接集成到你现有的工作流程中�
 
 > 映射新旧版本间200+ API端点——生成包含破坏性变更警告和代码示例的迁移指南。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/161-ai-api-migration-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -10153,7 +10153,7 @@ COCO的AI API迁移规划器直接集成到你现有的工作流程中，充当�
 
 > 运行100个定价场景结合弹性曲线和竞品数据——推荐使LTV最大化20%的层级结构。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/189-ai-pricing-strategy-modeler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -10277,7 +10277,7 @@ COCO的AI定价策略建模器直接集成到你现有的工作流程中，充�
 
 > 每晚扫描15个仓库的2000个依赖——按可利用性优先排序CVE并自动生成升级PR。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/198-ai-dependency-vulnerability-scanner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -10401,7 +10401,7 @@ COCO的AI依赖漏洞扫描器直接集成到你现有的工作流程中，充�
 
 > 按WCAG 2.2 AA标准扫描Web应用——标记200+检查点并提供修复建议和优先级排名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/204-ai-accessibility-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/industry/telecom.md
+++ b/docs/zh/use-cases/industry/telecom.md
@@ -6,7 +6,7 @@ AI驱动的电信行业用例。
 
 > 分析50+基站流量模式——在拥堵发生前3个月推荐扩容方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/119-ai-network-capacity-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI网络容量规划师直接集成到你现有的工作流程中，充�
 
 > 处理射频传播数据、地形图和分区规则——20分钟按覆盖潜力对50个候选站点排名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/134-ai-5g-site-survey-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI 5G站点勘测分析器直接集成到你现有的工作流程中，�
 
 > 基于30+行为信号对10万订户评分——提前45天以87%准确率识别可能流失客户。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/149-ai-churn-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI客户流失预测器直接集成到你现有的工作流程中，充�
 
 > 按生命周期阶段细分50万订户——在入网、升级和留存节点触发个性化营销。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/181-ai-subscriber-lifecycle-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI订户生命周期管理器直接集成到你现有的工作流程中�
 
 > 分析网络告警和客户投诉模式——提前6小时预测工单高峰以便客服增加人手。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/196-ai-service-ticket-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/compliance-officer.md
+++ b/docs/zh/use-cases/role/compliance-officer.md
@@ -6,7 +6,7 @@ AI驱动的合规官专业人员用例。
 
 > 跨部门追踪200+许可证申请——提前7天标记缺失文件和临近截止日期。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/114-ai-permit-application-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI许可证申请追踪器直接集成到你现有的工作流程中，�
 
 > 每日扫描NHTSA数据库和服务公告——将召回信息匹配车队库存并生成行动方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/120-ai-vehicle-recall-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI车辆召回监控器直接集成到你现有的工作流程中，充�
 
 > 从12个数据源汇总范围1-3排放数据——生成符合GHG协议的审计就绪碳排放报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/131-ai-carbon-footprint-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI碳足迹报告生成器直接集成到你现有的工作流程中，�
 
 > 扫描访问日志、加密配置和数据流——15分钟识别HIPAA违规并生成整改任务。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/136-ai-hipaa-compliance-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI HIPAA合规审计师直接集成到你现有的工作流程中，充�
 
 > 将课程项目与150+认证标准对照——突出差距并自动生成证据文档。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/152-ai-accreditation-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI认证合规检查器直接集成到你现有的工作流程中，充�
 
 > 从自然语言中提取事故细节——生成符合OSHA标准的报告，包含根因分析和纠正措施。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/156-ai-safety-incident-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI安全事故报告器直接集成到你现有的工作流程中，充�
 
 > 从10个部门收集ESG指标——2小时内起草符合TCFD和GRI标准的披露文件并验证数据。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/185-ai-esg-disclosure-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/consultant.md
+++ b/docs/zh/use-cases/role/consultant.md
@@ -6,7 +6,7 @@ AI驱动的咨询顾问专业人员用例。
 
 > 15分钟将市场数据、财务信息和竞争情报综合成10页战略简报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/112-ai-strategy-brief-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI战略简报撰写器直接集成到你现有的工作流程中，充�
 
 > 提取公开文件、新闻、诉讼记录和财务数据——2小时完成尽职调查报告，替代原来的2周。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/127-ai-due-diligence-compiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI尽职调查编撰器直接集成到你现有的工作流程中，充�
 
 > 将原始分析转化为麦肯锡风格幻灯片——25分钟构建30张包含图表、关键发现和建议的PPT。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/142-ai-management-consulting-deck-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI咨询方案构建器直接集成到你现有的工作流程中，充�
 
 > 分析作物照片和本地病虫害数据库——以95%准确率识别虫害并推荐治疗方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/145-ai-pest-detection-advisor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI病虫害检测顾问直接集成到你现有的工作流程中，充�
 
 > 收集50+同行运营KPI——排名客户绩效并识别达到上四分位的改进目标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/157-ai-benchmarking-analyst.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI对标分析师直接集成到你现有的工作流程中，充当一�
 
 > 基于公开数据构建TAM/SAM/SOM模型——20分钟生成自下而上和自上而下的估算及数据来源。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/174-ai-market-sizing-modeler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI市场规模建模器直接集成到你现有的工作流程中，充�
 
 > 运行100个定价场景结合弹性曲线和竞品数据——推荐使LTV最大化20%的层级结构。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/189-ai-pricing-strategy-modeler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/content-marketing.md
+++ b/docs/zh/use-cases/role/content-marketing.md
@@ -6,7 +6,7 @@ AI驱动的内容创作者、营销团队和品牌经理用例。
 
 > 20分钟产出一篇SEO优化的高质量文章，关键词研究到终稿一站式完成。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/010-ai-seo-content-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -211,7 +211,7 @@ COCO的AI SEO Content Writer将内容创作流水线从一个串行的、劳动�
 
 > 一次输入，全平台适配发布。每天3小时社媒运营缩减到15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/011-ai-social-media-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -398,7 +398,7 @@ COCO的AI Social Media Manager作为社交媒体团队的力量倍增器，处�
 
 > 10分钟生成200个A/B变体广告文案，数据驱动迭代优化。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/012-ai-ad-copy-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -607,7 +607,7 @@ COCO的AI Ad Copy Generator专为效果营销构建，理解各平台付费广�
 
 > 自动汇聚行业资讯，5小时/周的人工策展变为30分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/013-ai-newsletter-curator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -759,7 +759,7 @@ COCO的AI Newsletter Curator自动化Newsletter制作中劳动密集的部分，
 
 > 实时追踪竞品动态，2天调研变为1小时自动化输出。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/014-ai-competitive-copywriter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -934,7 +934,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 品牌危机发现时间从72小时降至11分钟，覆盖率从10%到97%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/040-ai-brand-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1040,7 +1040,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 达人审核从15小时降至20分钟，投放ROI从0.8倍提升到4.2倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/041-ai-influencer-finder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1146,7 +1146,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 统一6渠道23个活动的归因分析，ROAS提升37%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/042-ai-campaign-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1252,7 +1252,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 内容规划从每周8小时降至45分钟，发布一致性从62%到96%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/043-ai-content-calendar.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1358,7 +1358,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 用户画像创建从6周缩短到2天，细分准确度89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/044-ai-persona-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1464,7 +1464,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 产品反馈分析从2周缩短到2小时，覆盖100%的用户反馈。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/070-ai-product-feedback-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1643,7 +1643,7 @@ COCO的AI产品反馈分析器将这种混乱转变为流畅的智能工作流�
 
 > 本地化周期从6周缩短到3天，翻译一致性提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/076-ai-localization-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1822,7 +1822,7 @@ COCO的AI本地化管理器将这种混乱转变为流畅的智能工作流。�
 
 > 营销ROI报告生成从3天降至实时，跨渠道归因准确率92%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/079-ai-marketing-roi-dashboard.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2001,7 +2001,7 @@ COCO的AI营销ROI仪表盘将这种混乱转变为流畅的智能工作流。�
 
 > 竞品动态检测从每月一次变为实时，战略响应速度提升5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/084-ai-competitive-intelligence-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2180,7 +2180,7 @@ COCO的AI竞争情报追踪器将这种混乱转变为流畅的智能工作流�
 
 > 品牌提及监测覆盖率从15%提升到96%，危机响应时间降至15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/089-ai-social-listening-agent.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2379,7 +2379,7 @@ COCO的AI社交媒体监听助手作为7×24小时品牌情报系统运作，覆
 
 > 职位广告点击率提升65%，优质候选人申请量增加40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/093-ai-recruitment-marketing-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2558,7 +2558,7 @@ COCO的AI招聘营销文案助手将这种混乱转变为流畅的智能工作�
 
 > 调研回复率从3%提升到28%，可操作洞察产出量增加5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/094-ai-customer-survey-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2803,7 +2803,7 @@ COCO的AI客户调研设计师将调查从粗糙的工具转变为精准的反�
 
 > 需求预测误差从35%降至8%，库存成本降低28%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/100-ai-demand-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3002,7 +3002,7 @@ COCO的AI需求预测器通过结合先进的机器学习和外部信号集成�
 
 > 演示文稿制作从15小时降至1小时，客户定制度提升300%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/101-ai-pitch-deck-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3207,7 +3207,7 @@ COCO的AI演示文稿构建器将演示创建从手动、耗时的苦差事转�
 
 > 在6个平台上为客人评论撰写个性化回复——每条30秒，完美匹配品牌语调。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/110-ai-hotel-review-responder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3331,7 +3331,7 @@ COCO的AI酒店评论回复器直接集成到你现有的工作流程中，充�
 
 > 转录60分钟节目，提取关键引用，4分钟生成带时间戳的SEO优化节目笔记。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/133-ai-podcast-show-notes-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3455,7 +3455,7 @@ COCO的AI播客节目笔记撰写器直接集成到你现有的工作流程中�
 
 > 按生命周期阶段细分50万订户——在入网、升级和留存节点触发个性化营销。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/181-ai-subscriber-lifecycle-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3579,7 +3579,7 @@ COCO的AI订户生命周期管理器直接集成到你现有的工作流程中�
 
 > 按观看历史、人口统计和互动数据聚类200万观众——构建12个可操作画像用于定向内容策略。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/195-ai-audience-segmentation-engine.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/customer-support.md
+++ b/docs/zh/use-cases/role/customer-support.md
@@ -6,7 +6,7 @@ AI驱动的客服团队、帮助台和客户成功用例。
 
 > 工单自动分类路由，5分钟/单变为即时处理。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/021-ai-ticket-classifier.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -161,7 +161,7 @@ SLA层级：[按优先级列出你的SLA要求]
 
 > 1小时生成50篇知识库文章，从工单和对话自动提取。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/022-ai-knowledge-base-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -319,7 +319,7 @@ COCO的AI Knowledge Base Builder将已解决的客服工单转化为已发布的
 
 > AI一键支持15+语言客服，替代5个翻译人员。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/023-ai-multi-language-support.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -479,7 +479,7 @@ COCO的AI Multi-Language Support提供母语质量的多语言客户服务，无
 
 > 自动识别VIP客户异常，30%漏检降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/024-ai-vip-escalation.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -636,7 +636,7 @@ CSM：[姓名]
 
 > 客服机器人解决率从27%提至78%，训练时间从6个月到2周。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/050-ai-chatbot-trainer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -742,7 +742,7 @@ CSM：[姓名]
 
 > 工单分流+45%，FAQ覆盖从120篇到850+篇，每周节省23小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/054-ai-faq-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -848,7 +848,7 @@ CSM：[姓名]
 
 > 客户流失预警提前30天发现，挽回率从15%提升到42%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/069-ai-customer-success-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1027,7 +1027,7 @@ COCO的AI客户成功监控器将这种混乱转变为流畅的智能工作流�
 
 > 客户入驻时间从3周缩短到3天，首月激活率提升55%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/078-ai-customer-onboarding-guide.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1206,7 +1206,7 @@ COCO的AI客户入驻引导助手将这种混乱转变为流畅的智能工作�
 
 > 分析网络告警和客户投诉模式——提前6小时预测工单高峰以便客服增加人手。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/196-ai-service-ticket-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/data-analyst.md
+++ b/docs/zh/use-cases/role/data-analyst.md
@@ -6,7 +6,7 @@ AI驱动的数据分析师专业人员用例。
 
 > 提取20+可比房产数据，调整位置和条件因素，5分钟生成市场估值报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/108-ai-property-valuation-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI房产估值助手直接集成到你现有的工作流程中，充当�
 
 > 结合气象数据、土壤报告和历史产量，以8%以内的误差预测收获量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/115-ai-crop-yield-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI作物产量预测器直接集成到你现有的工作流程中，充�
 
 > 阅读120页剧本生成专业评审——8分钟完成剧情概要、角色分析和市场适配度评估。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/118-ai-script-coverage-reader.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI剧本评审阅读器直接集成到你现有的工作流程中，充�
 
 > 将患者记录与40+试验标准匹配——筛选合格候选人速度比人工快10倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/121-ai-clinical-trial-screener.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI临床试验筛查器直接集成到你现有的工作流程中，充�
 
 > 同时搜索15个政府数据库——5分钟编撰房产、法院和商业记录。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/129-ai-public-records-researcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI公共记录研究员直接集成到你现有的工作流程中，充�
 
 > 处理射频传播数据、地形图和分区规则——20分钟按覆盖潜力对50个候选站点排名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/134-ai-5g-site-survey-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI 5G站点勘测分析器直接集成到你现有的工作流程中，�
 
 > 处理市政厅和调查中的1万+市民评论——将主题、情绪和紧急程度聚类为可操作简报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/144-ai-constituent-feedback-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -874,7 +874,7 @@ COCO的AI选民反馈分析器直接集成到你现有的工作流程中，充�
 
 > 对照50项风险因素评估申请人数据——8分钟生成带置信度评分的核保建议。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/147-ai-underwriting-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -998,7 +998,7 @@ COCO的AI核保助手直接集成到你现有的工作流程中，充当一个�
 
 > 从8个数据源汇总项目数据——20分钟生成包含可视化和成果指标的资助方报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/158-ai-impact-measurement-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1122,7 +1122,7 @@ COCO的AI影响力评估报告器直接集成到你现有的工作流程中，�
 
 > 从上传的平面图提取房间尺寸、计算可用面积并标记违规——仅需2分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/166-ai-floor-plan-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1246,7 +1246,7 @@ COCO的AI平面图分析器直接集成到你现有的工作流程中，充当�
 
 > 解读50个田区的pH值、营养和有机质化验结果——推荐施肥方案及成本估算。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/177-ai-soil-health-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1370,7 +1370,7 @@ COCO的AI土壤健康报告器直接集成到你现有的工作流程中，充�
 
 > 分析10万条理赔记录——以92%精度识别可疑聚类和伪造事故指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/179-ai-fraud-pattern-detector.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1494,7 +1494,7 @@ COCO的AI欺诈模式检测器直接集成到你现有的工作流程中，充�
 
 > 建模人口趋势、申请漏斗和竞争动态——以3%以内误差预测下一年招生人数。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/184-ai-enrollment-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/dev.md
+++ b/docs/zh/use-cases/role/dev.md
@@ -6,7 +6,7 @@ AI驱动的开发者、DevOps工程师和技术负责人用例。
 
 > 自动审查每个PR：Bug、安全漏洞、性能问题——15分钟出完整报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/005-ai-code-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -146,7 +146,7 @@ PR信息：
 
 > 读取源码，30分钟生成包含边界条件的完整测试。覆盖率从34%提升到89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/006-ai-test-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -322,7 +322,7 @@ Bug描述：[描述bug]
 
 > 实时监控每次部署，90秒检测异常，自动回滚。MTTR从47分钟降至2分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/007-ai-deploy-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -493,7 +493,7 @@ COCO的AI Deploy Monitor作为智能层叠加在你现有的监控基础设施�
 
 > 从代码库自动生成并同步API文档，多语言示例，零偏差。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/008-ai-api-doc-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -678,7 +678,7 @@ API概述：[简要描述API功能]
 
 > 粘贴错误日志，AI从症状追溯到根因，提供可直接应用的修复diff。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/009-ai-debug-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -877,7 +877,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 230万行遗留代码迁移从8年缩短到14个月，缺陷率从23%降至3%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/035-ai-code-migrator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -983,7 +983,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 页面加载从4.7秒优化到0.9秒，3周诊断时间变4小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/036-ai-performance-profiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1089,7 +1089,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 持续安全扫描，误报率从91%降至8%，修复时间从38天到4天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/037-ai-security-scanner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1195,7 +1195,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 慢查询从12秒优化到0.3秒，云计算成本降低42%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/038-ai-database-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1300,7 +1300,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 自动管理1847个依赖，23个CVE全部清零，更新成功率94%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/039-ai-dependency-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1406,7 +1406,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > Bug分诊从6小时/Sprint降至30分钟，严重Bug修复从14天到3天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/051-ai-bug-prioritizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1512,7 +1512,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 工单误路由减少89%，升级解决时间从24小时降至2小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/074-ai-helpdesk-escalation-router.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1691,7 +1691,7 @@ COCO的AI工单升级路由器将这种混乱转变为流畅的智能工作流�
 
 > 数据管道故障检测从小时级降至秒级，数据质量问题减少91%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/075-ai-data-pipeline-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1870,7 +1870,7 @@ COCO的AI数据管道监控器将这种混乱转变为流畅的智能工作流�
 
 > 事件响应时间从45分钟降至8分钟，MTTR减少73%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/080-ai-incident-response-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2049,7 +2049,7 @@ COCO的AI事件响应协调器将这种混乱转变为流畅的智能工作流�
 
 > 专利检索从3周缩短到4小时，现有技术覆盖率从60%提升到97%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/081-ai-patent-research-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2228,7 +2228,7 @@ COCO的AI专利研究助手将这种混乱转变为流畅的智能工作流。�
 
 > QA覆盖率从40%提升到92%，回归缺陷减少67%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/083-ai-quality-assurance-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2407,7 +2407,7 @@ COCO的AI质量保证审计器将这种混乱转变为流畅的智能工作流�
 
 > 技术文档编写从3天降至2小时，文档与代码同步率99%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/087-ai-technical-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2595,7 +2595,7 @@ SDK语言：[语言]
 
 > IT资产可见性从45%提升到99%，影子IT发现率提升10倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/099-ai-it-asset-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2828,7 +2828,7 @@ COCO的AI IT资产管理器为您组织中的每项技术资产创建全面、�
 
 > 映射新旧版本间200+ API端点——生成包含破坏性变更警告和代码示例的迁移指南。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/161-ai-api-migration-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2952,7 +2952,7 @@ COCO的AI API迁移规划器直接集成到你现有的工作流程中，充当�
 
 > 映射新旧电子病历系统间的字段——转换50万条患者记录，带验证检查和错误日志。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/168-ai-ehr-data-migrator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3076,7 +3076,7 @@ COCO的AI电子病历数据迁移器直接集成到你现有的工作流程中�
 
 > 每晚扫描15个仓库的2000个依赖——按可利用性优先排序CVE并自动生成升级PR。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/198-ai-dependency-vulnerability-scanner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/devops.md
+++ b/docs/zh/use-cases/role/devops.md
@@ -6,7 +6,7 @@ AI驱动的DevOps运维专业人员用例。
 
 > 分析50+基站流量模式——在拥堵发生前3个月推荐扩容方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/119-ai-network-capacity-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI网络容量规划师直接集成到你现有的工作流程中，充�
 
 > 实时追踪2000+太阳能板产出——10分钟内检测衰减、遮挡问题和逆变器故障。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/146-ai-solar-panel-performance-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/executive.md
+++ b/docs/zh/use-cases/role/executive.md
@@ -6,7 +6,7 @@ AI驱动的高管专业人员用例。
 
 > 将6个部门数据综合为2页周一晨报——KPI、风险、待决事项，仅需5分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/167-ai-executive-briefing-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI高管简报生成器直接集成到你现有的工作流程中，充�
 
 > 提取财务、项目成果和捐赠数据——3小时汇编包含图表和叙述的印刷就绪年度报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/190-ai-annual-report-assembler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI年度报告汇编器直接集成到你现有的工作流程中，充�
 
 > 从Jira、Salesforce等6个工具同步关键结果——生成周度OKR评分卡显示红黄绿状态。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/200-ai-okr-progress-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI OKR进度追踪器直接集成到你现有的工作流程中，充当�
 
 > 从8个部门更新汇编董事会资料包——将财务、战略和表决事项格式化为品牌化40页PPT。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/203-ai-board-meeting-prep-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/finance.md
+++ b/docs/zh/use-cases/role/finance.md
@@ -6,7 +6,7 @@ AI驱动的财务团队、会计师和财务分析师用例。
 
 > 费用报告即时审核，合规自动通过，异常自动标记。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/029-ai-expense-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -162,7 +162,7 @@ COCO的AI Expense Auditor提供100%的审计覆盖和一致的政策执行。
 
 > 3小时生成多源数据对账的财务报告，替代2天人工。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/030-ai-financial-report-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -300,7 +300,7 @@ COCO的AI Financial Report Generator自动化数据组装、计算和叙事生�
 
 > 30秒处理一张发票：提取、匹配、路由全自动。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/031-ai-invoice-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -467,7 +467,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 现金流预测准确率从64%提至93%，全年零现金危机。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/060-ai-cash-flow-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -573,7 +573,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 交易合规检查覆盖率从5%到100%，审计准备从6周到3天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/061-ai-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -679,7 +679,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 法律文档起草从5天缩短到2小时，合规风险降低85%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/068-ai-legal-document-drafter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -858,7 +858,7 @@ COCO的AI法律文档起草助手将这种混乱转变为流畅的智能工作�
 
 > 监管申报准备时间减少78%，合规错误降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/071-ai-regulatory-filing-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1037,7 +1037,7 @@ COCO的AI合规申报助手将这种混乱转变为流畅的智能工作流。�
 
 > 税务准备时间减少70%，申报错误降低92%，罚款归零。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/085-ai-tax-preparation-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1216,7 +1216,7 @@ COCO的AI税务准备助手将这种混乱转变为流畅的智能工作流。�
 
 > 发票核对时间减少85%，差异检出率从72%提升到99.5%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/088-ai-vendor-invoice-reconciler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1395,7 +1395,7 @@ COCO的AI供应商发票核对器将这种混乱转变为流畅的智能工作�
 
 > 租赁合同审查从5天降至1小时，隐藏条款识别率提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/091-ai-lease-agreement-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1583,7 +1583,7 @@ COCO的AI租赁合同审查师充当你不知疲倦的租赁分析师，结合�
 
 > 差旅费用合规率从68%提升到97%，差旅开支节省23%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/092-ai-travel-expense-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1782,7 +1782,7 @@ COCO的AI差旅费用优化师管理从预订到报销的整个差旅生命周�
 
 > 董事会报告编制从40小时降至4小时，数据准确率达99.8%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/096-ai-board-report-compiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1999,7 +1999,7 @@ KPI数据（本季度 vs 上季度 vs 计划）：
 
 > 计算每道菜品的食材成本占比——建议价格调整和替代方案以达到30%毛利目标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/125-ai-menu-cost-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2123,7 +2123,7 @@ COCO的AI菜单成本分析器直接集成到你现有的工作流程中，充�
 
 > 处理8个平台的流媒体数据——30分钟按分成协议精确计算5万首曲目的艺人版税。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/148-ai-royalty-calculator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2247,7 +2247,7 @@ COCO的AI版税计算器直接集成到你现有的工作流程中，充当一�
 
 > 阅读临床记录分配ICD-10和CPT编码——首次准确率96%，拒付率降低40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/151-ai-medical-coding-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2371,7 +2371,7 @@ COCO的AI医疗编码助手直接集成到你现有的工作流程中，充当�
 
 > 每月对比200个预算项的实际支出——突出超过5%的差异并提供下钻分析。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/176-ai-budget-variance-analyst.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2495,7 +2495,7 @@ COCO的AI预算差异分析师直接集成到你现有的工作流程中，充�
 
 > 监控现货价格、天气预报和需求曲线——建议次日能源市场的最优买卖时间窗口。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/178-ai-energy-trading-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2619,7 +2619,7 @@ COCO的AI能源交易助手直接集成到你现有的工作流程中，充当�
 
 > 基于需求、活动和竞争定价动态调整房价——比静态定价提升12% RevPAR。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/187-ai-revenue-management-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2743,7 +2743,7 @@ COCO的AI收益管理优化器直接集成到你现有的工作流程中，充�
 
 > 对保险账簿运行500个死亡率和发病率情景——30分钟压力测试准备金并突出资金不足环节。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/194-ai-actuarial-scenario-runner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/hr-recruiting.md
+++ b/docs/zh/use-cases/role/hr-recruiting.md
@@ -6,7 +6,7 @@ AI驱动的HR团队、招聘人员和人力运营用例。
 
 > 2小时筛选500份简历，替代3天人工筛选。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/025-ai-resume-screener.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -159,7 +159,7 @@ COCO的AI Resume Screener对每份申请进行深度、一致的分析，对照�
 
 > 10分钟生成无偏见、SEO优化的职位描述。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/026-ai-job-description-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -334,7 +334,7 @@ COCO的AI Job Description Writer创建引人注目的、包容的、高效的职
 
 > 3分钟完成面试排期，自动协调多方日历。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/027-ai-interview-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -492,7 +492,7 @@ COCO的AI Interview Scheduler自动化从初始可用性到确认的整个排期
 
 > 新员工3天完成入职，替代传统2周流程。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/028-ai-onboarding-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -670,7 +670,7 @@ COCO的AI Onboarding Assistant协调从offer接受到90天里程碑的整个入�
 
 > 员工调查响应率从31%提至82%，离职预测89%准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/055-ai-employee-pulse.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -776,7 +776,7 @@ COCO的AI Onboarding Assistant协调从offer接受到90天里程碑的整个入�
 
 > 培训完成率从23%提至71%，6个月技能差距关闭64%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/056-ai-training-recommender.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -882,7 +882,7 @@ COCO的AI Onboarding Assistant协调从offer接受到90天里程碑的整个入�
 
 > 实时薪酬对标，Offer竞争力从52%提至89%，遗憾离职降35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/057-ai-comp-benchmarker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -988,7 +988,7 @@ COCO的AI Onboarding Assistant协调从offer接受到90天里程碑的整个入�
 
 > 绩效评审撰写从40小时降至6小时，可操作反馈从24%提至87%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/058-ai-review-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1094,7 +1094,7 @@ COCO的AI Onboarding Assistant协调从offer接受到90天里程碑的整个入�
 
 > 员工离职流程从2周缩短到1天，权限撤销遗漏降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/082-ai-employee-offboarding-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1273,7 +1273,7 @@ COCO的AI员工离职管理器将这种混乱转变为流畅的智能工作流�
 
 > 合规培训完成率从52%提升到96%，逾期培训降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/097-ai-compliance-training-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/legal.md
+++ b/docs/zh/use-cases/role/legal.md
@@ -6,7 +6,7 @@ AI驱动的法律专业人员用例。
 
 > 60秒生成符合管辖区要求的保密协议——根据交易背景定制范围、期限和例外条款。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/123-ai-nda-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI保密协议生成器直接集成到你现有的工作流程中，充�
 
 > 将专利组合与竞争对手申请对比——跨300+专利识别空白领域和潜在侵权风险。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/138-ai-ip-portfolio-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI知识产权组合分析器直接集成到你现有的工作流程中�
 
 > 搜索USPTO、EUIPO等20+商标数据库——10分钟交付带风险评分的全面冲突报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/153-ai-trademark-conflict-searcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI商标冲突检索器直接集成到你现有的工作流程中，充�
 
 > 对照豁免标准审查信息公开请求——编辑敏感内容并起草回复，处理周期从30天缩短到5天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/159-ai-foia-request-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI信息公开请求处理器直接集成到你现有的工作流程中�
 
 > 每日监控SEC、FINRA和12个全球监管机构——将新规映射到合规义务，提前48小时预警。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/164-ai-regulatory-change-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI法规变更追踪器直接集成到你现有的工作流程中，充�
 
 > 识别保管人、发送保全通知、追踪确认并监控合规——管理50+活跃保全，零遗漏截止日期。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/170-ai-litigation-hold-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -750,7 +750,7 @@ COCO的AI诉讼保全管理器直接集成到你现有的工作流程中，充�
 
 > 跨30个地区追踪1万+作品的授权窗口——权利到期前60天提醒续约决策。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/180-ai-content-rights-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -874,7 +874,7 @@ COCO的AI内容版权追踪器直接集成到你现有的工作流程中，充�
 
 > 审查80页购电协议——10分钟标记价格升级条款、限电风险和不利条款。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/193-ai-power-purchase-agreement-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/logistics-manager.md
+++ b/docs/zh/use-cases/role/logistics-manager.md
@@ -6,7 +6,7 @@ AI驱动的物流经理专业人员用例。
 
 > 跨承运商监控500+在途货物——在延误影响交付前4小时发出预警。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/109-ai-shipment-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI货运追踪器直接集成到你现有的工作流程中，充当一�
 
 > 分析拣货频率和订单模式——重新设计仓库分区，平均拣货时间缩短35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/124-ai-warehouse-layout-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI仓库布局优化器直接集成到你现有的工作流程中，充�
 
 > 规划每日80个站点的最优配送路线——综合交通、时间窗和车辆容量，燃油成本降低20%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/139-ai-route-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI路线优化器直接集成到你现有的工作流程中，充当一�
 
 > 跨5家承运商追踪每日2000次配送——自动就延误联系客户并建议重新配送时间。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/165-ai-last-mile-delivery-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI最后一公里配送追踪器直接集成到你现有的工作流程�
 
 > 在20个月台协调进出车辆——通过实时时段优化将停留时间缩短45%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/171-ai-cross-dock-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -626,7 +626,7 @@ COCO的AI越库调度器直接集成到你现有的工作流程中，充当一�
 
 > 将货物归入HS编码、计算关税并预填报关单——清关时间从48小时缩短到6小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/186-ai-customs-declaration-filer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/operations.md
+++ b/docs/zh/use-cases/role/operations.md
@@ -6,7 +6,7 @@ AI驱动的运营经理、采购和通用业务运营用例。
 
 > 会议结束即出纪要：转录、摘要、待办分配一步到位。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/032-ai-meeting-notes.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -168,7 +168,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 实时库存预测，替代每周手动盘点，减少滞销和缺货。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/033-ai-inventory-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -326,7 +326,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 2小时完成供应商评估排名，替代1周人工调研。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/034-ai-vendor-evaluator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -473,7 +473,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > SLA违约从12次/季降至1次/季，罚金从$20万/年降至$1.5万/年。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/052-ai-sla-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -579,7 +579,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 847份政策文档更新从6周缩短到4天，合规风险降89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/059-ai-policy-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -685,7 +685,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 流程时间从14天降至4天，返工率从31%降至8%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/062-ai-process-miner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -791,7 +791,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 文档搜索从18分钟降至30秒，错误分类从34%降至3%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/063-ai-document-classifier.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -897,7 +897,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 风险预测84%准确，每年预防$420万损失。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/064-ai-risk-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1003,7 +1003,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 数据录入自动化，准确率从96%提升至99.7%，处理时间减少94%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/065-ai-data-entry-automator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1190,7 +1190,7 @@ COCO的AI数据录入自动化工具连接你现有的文档来源和目标系�
 
 > 邮件处理时间减少73%，优先邮件响应从4.2小时降至23分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/066-ai-email-triage-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1361,7 +1361,7 @@ COCO的AI邮件分诊管理器将这种混乱转变为流畅的智能工作流�
 
 > 会议安排后勤时间减少87%，跨时区会议安排速度提升3倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/067-ai-meeting-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1531,7 +1531,7 @@ COCO的AI会议调度助手将这种混乱转变为流畅的智能工作流。�
 
 > 供应链可视性从30%提升到95%，中断响应时间减少76%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/077-ai-supply-chain-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1710,7 +1710,7 @@ COCO的AI供应链追踪器将这种混乱转变为流畅的智能工作流。�
 
 > 90秒数字化患者入院表——将人口统计、保险信息和病史自动录入电子病历系统。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/106-ai-patient-intake-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1834,7 +1834,7 @@ COCO的AI患者入院处理器直接集成到你现有的工作流程中，充�
 
 > 根据资助方要求撰写拨款申请——20分钟生成预算、时间表和影响力指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/113-ai-grant-proposal-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1958,7 +1958,7 @@ COCO的AI拨款申请撰写器直接集成到你现有的工作流程中，充�
 
 > 关联1000+电网节点传感器数据——2分钟定位故障根因，替代原来的2小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/116-ai-grid-outage-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2082,7 +2082,7 @@ COCO的AI电网故障分析器直接集成到你现有的工作流程中，充�
 
 > 对照保单条款审核理赔申请——自动通过简单案件，处理时间从5天缩短到4小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/117-ai-claims-adjuster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2206,7 +2206,7 @@ COCO的AI理赔评估师直接集成到你现有的工作流程中，充当一�
 
 > 分析100+设备的振动、温度和运行数据——在故障前安排维护，停机时间减少40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/126-ai-predictive-maintenance-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2330,7 +2330,7 @@ COCO的AI预测性维护调度器直接集成到你现有的工作流程中，�
 
 > 结合土壤湿度传感器、天气预报和作物需求——优化灌溉计划，减少30%用水量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/130-ai-irrigation-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2454,7 +2454,7 @@ COCO的AI灌溉调度器直接集成到你现有的工作流程中，充当一�
 
 > 根据技能、空闲时间和历史表现将500名志愿者匹配到30个活动岗位——自动发送确认。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/143-ai-volunteer-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2578,7 +2578,7 @@ COCO的AI志愿者协调器直接集成到你现有的工作流程中，充当�
 
 > 跨3个系统同步OEM零件编号、定价和适配数据——每晚核对保持8万SKU准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/150-ai-parts-catalog-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2702,7 +2702,7 @@ COCO的AI零件目录更新器直接集成到你现有的工作流程中，充�
 
 > 将20页患者病历浓缩为结构化1页摘要——突出活跃问题、用药和待处理医嘱。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/162-ai-clinical-notes-summarizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2826,7 +2826,7 @@ COCO的AI临床笔记摘要器直接集成到你现有的工作流程中，充�
 
 > 根据退房时间、特殊需求和距离将80间房分配给15名清洁员——周转时间缩短25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/172-ai-housekeeping-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2950,7 +2950,7 @@ COCO的AI客房清洁调度器直接集成到你现有的工作流程中，充�
 
 > 排序200个生产订单以最小化换线时间——在满足所有交期的同时提升15%产量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/173-ai-production-batch-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3074,7 +3074,7 @@ COCO的AI生产批次优化器直接集成到你现有的工作流程中，充�
 
 > 处理500辆车的GPS、油耗和驾驶行为数据——生成周度评分卡，发现每年$8万节油机会。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/182-ai-fleet-telematics-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3198,7 +3198,7 @@ COCO的AI车队远程信息分析器直接集成到你现有的工作流程中�
 
 > 追踪1000头牲畜的采食量、运动和体温——在可见症状出现前48小时检测疾病指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/192-ai-livestock-health-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3322,7 +3322,7 @@ COCO的AI牲畜健康监控器直接集成到你现有的工作流程中，充�
 
 > 提取信用、就业和租赁历史——3分钟生成符合公平住房法的带风险评分筛查报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/199-ai-tenant-screening-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/pm.md
+++ b/docs/zh/use-cases/role/pm.md
@@ -6,7 +6,7 @@ AI驱动的项目经理专业人员用例。
 
 > 协调300人活动的场地、餐饮、音视频和人员——15分钟生成时间线、检查单和供应商订单。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/155-ai-event-logistics-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI活动后勤规划器直接集成到你现有的工作流程中，充�
 
 > 策划500人晚宴——在一个面板管理RSVP、座位安排、拍卖目录和赞助方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/175-ai-fundraising-event-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/procurement.md
+++ b/docs/zh/use-cases/role/procurement.md
@@ -6,7 +6,7 @@ AI驱动的采购专业人员用例。
 
 > 将BOM与5000+供应商目录交叉验证——3分钟发现停产零件并建议替代方案以降低成本。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/141-ai-bill-of-materials-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI物料清单检查器直接集成到你现有的工作流程中，充�
 
 > 将运费与200+航线的市场数据对标——发现平均每批货物可节省12%的机会。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/154-ai-freight-rate-negotiator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI运费谈判助手直接集成到你现有的工作流程中，充当�
 
 > 跨地缘政治、财务和天气风险因素监控300家供应商——每日生成带缓解措施的风险评分卡。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/160-ai-supply-chain-risk-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI供应链风险评分器直接集成到你现有的工作流程中，�
 
 > 对比5家PBM的药品目录方案——找到节省22%药品支出的等效替代品，不影响疗效。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/183-ai-pharmacy-benefit-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI药品福利优化器直接集成到你现有的工作流程中，充�
 
 > 按25项加权标准评分30份供应商投标——45分钟生成比较矩阵并筛选前3名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/191-ai-procurement-bid-evaluator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/product.md
+++ b/docs/zh/use-cases/role/product.md
@@ -6,7 +6,7 @@ AI驱动的产品经理、项目管理和产品运营用例。
 
 > 100%处理14000条月度反馈，问题发现从3周到24小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/053-ai-sentiment-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -112,7 +112,7 @@ AI驱动的产品经理、项目管理和产品运营用例。
 
 > 项目状态报告编写从4小时降至15分钟，实时数据自动聚合。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/072-ai-project-status-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -291,7 +291,7 @@ COCO的AI项目状态报告生成器将这种混乱转变为流畅的智能工�
 
 > 冲刺规划会议从3小时缩短到45分钟，交付准确率提升38%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/090-ai-sprint-planning-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -488,7 +488,7 @@ COCO的AI冲刺规划助手将冲刺规划从主观辩论转变为数据驱动�
 
 > 发版说明编写从3-4小时降至5分钟，功能采用率提升35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/095-ai-release-notes-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -752,7 +752,7 @@ Git日志：
 
 > 跨部门工作流自动化率从15%提升到78%，处理时间减少65%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/103-ai-workflow-automator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/qa-engineer.md
+++ b/docs/zh/use-cases/role/qa-engineer.md
@@ -6,7 +6,7 @@ AI驱动的QA工程师专业人员用例。
 
 > 分析产线照片和传感器数据——产品出厂前以98.5%准确率捕捉缺陷。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/111-ai-production-defect-detector.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI生产缺陷检测器直接集成到你现有的工作流程中，充�
 
 > 实时监控50张控制图——在产生废品前3个班次检测到超差趋势，自动触发警报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/188-ai-spc-chart-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI统计过程控制监控器直接集成到你现有的工作流程中�
 
 > 按WCAG 2.2 AA标准扫描Web应用——标记200+检查点并提供修复建议和优先级排名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/204-ai-accessibility-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/sales.md
+++ b/docs/zh/use-cases/role/sales.md
@@ -6,7 +6,7 @@ AI驱动的SDR、客户经理和销售负责人用例。
 
 > 一天调研200个线索，自动从LinkedIn、企查查抓取并打分。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/015-ai-lead-researcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -190,7 +190,7 @@ LinkedIn URL：[URL]
 
 > 通话、邮件、会议自动同步CRM，45分钟/天数据录入变为0。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/016-ai-crm-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -348,7 +348,7 @@ Pipeline数据：
 
 > 15分钟生成定制化方案书，基于客户需求自动匹配。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/017-ai-proposal-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -521,7 +521,7 @@ RFP问题/要求：
 
 > 2分钟生成个性化跟进邮件，基于会议上下文和客户行为。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/018-ai-follow-up-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -694,7 +694,7 @@ COCO的AI Follow-up Writer通过生成及时、有上下文的跟进沟通确保
 
 > 8分钟生成客户会议简报，多源情报汇聚，高管画像深入。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/019-ai-client-research-brief.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -844,7 +844,7 @@ COCO的AI Client Research Brief在几分钟内为每次客户会议提供全面�
 
 > 10分钟完成复杂报价计算，自动匹配折扣规则和审批流程。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/020-ai-quote-calculator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1007,7 +1007,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 销售预测误差从40%降至8%，成交预测91%准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/045-ai-sales-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1113,7 +1113,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 演示准备从4小时降至15分钟，演示转化率从18%提至34%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/046-ai-demo-personalizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1219,7 +1219,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 实时竞品定价监控，响应时间从3周到4小时，用户收入+23%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/047-ai-pricing-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1325,7 +1325,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 合同审查从5天降至45分钟，风险检出率从72%提至99%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/048-ai-contract-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1431,7 +1431,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 客户流失预测87%准确，挽回率从12%提至41%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/049-ai-churn-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1537,7 +1537,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 销售区域平衡度提升45%，区域间业绩差距缩小60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/073-ai-sales-territory-mapper.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1716,7 +1716,7 @@ COCO的AI销售区域规划器将这种混乱转变为流畅的智能工作流�
 
 > 流失客户挽回率从8%提升到35%，获客成本降低60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/086-ai-customer-win-back-campaigner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1895,7 +1895,7 @@ COCO的AI客户挽回营销器将这种混乱转变为流畅的智能工作流�
 
 > 销售异议处理成功率从35%提升到72%，成交周期缩短25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/098-ai-sales-objection-handler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2127,7 +2127,7 @@ COCO的AI销售异议处理器将经验知识转化为可扩展的、始终最�
 
 > 客户健康度评估覆盖率从20%提升到100%，流失预警准确率87%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/102-ai-customer-health-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2339,7 +2339,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > RFP响应时间从40小时降至8小时，中标率从5%提升到18%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/104-ai-rfp-response-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2569,7 +2569,7 @@ RFP表现数据（过去12个月）：
 
 > 对5000+捐赠者进行参与度、捐赠历史和能力评分——优先联络以提升续捐率25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/128-ai-donor-engagement-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2693,7 +2693,7 @@ COCO的AI捐赠者互动追踪器直接集成到你现有的工作流程中，�
 
 > 分析理赔历史、风险画像和市场费率——到期前30天推荐最优续保方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/132-ai-policy-renewal-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2817,7 +2817,7 @@ COCO的AI保单续保优化器直接集成到你现有的工作流程中，充�
 
 > 将客户偏好与15家经销商库存匹配——推荐最佳车型并估算置换价格。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/135-ai-dealership-inventory-matcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2941,7 +2941,7 @@ COCO的AI经销商库存匹配器直接集成到你现有的工作流程中，�
 
 > 分析预订历史和客人画像——推荐个性化房间升级和套餐，RevPAR提升18%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/140-ai-guest-upsell-recommender.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3065,7 +3065,7 @@ COCO的AI客人升级推荐器直接集成到你现有的工作流程中，充�
 
 > 筛选在线潜客、匹配车型偏好并预约试驾——以确认预约填满90%可用时段。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/197-ai-test-drive-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3189,7 +3189,7 @@ COCO的AI试驾调度器直接集成到你现有的工作流程中，充当一�
 
 > 绘制200名医师的转诊模式——识别高价值关系缺口和拓展优先级。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/201-ai-referral-network-mapper.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3313,7 +3313,7 @@ COCO的AI转诊网络绘制器直接集成到你现有的工作流程中，充�
 
 > 提取30笔近期成交，调整特征和时间因素——生成含照片和定价依据的客户报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/202-ai-comparative-market-analysis.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/role/trainer.md
+++ b/docs/zh/use-cases/role/trainer.md
@@ -6,7 +6,7 @@ AI驱动的培训师专业人员用例。
 
 > 10分钟内生成12周课程大纲——包含学习目标、作业设计和评分标准。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/107-ai-curriculum-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -130,7 +130,7 @@ COCO的AI课程设计师直接集成到你现有的工作流程中，充当一�
 
 > 汇总200名学生的成绩、出勤和参与数据——每周标记高风险学生并建议干预措施。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/122-ai-student-progress-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -254,7 +254,7 @@ COCO的AI学生进度追踪器直接集成到你现有的工作流程中，充�
 
 > 将学生提交内容与1000万+来源和AI生成模式对比——标记可疑段落并给出置信度评分。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/137-ai-plagiarism-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -378,7 +378,7 @@ COCO的AI抄袭检测器直接集成到你现有的工作流程中，充当一�
 
 > 按评分标准批改研究论文——2分钟提供论证、证据和写作质量的段落级反馈。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/163-ai-research-paper-grader.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -502,7 +502,7 @@ COCO的AI论文评分助手直接集成到你现有的工作流程中，充当�
 
 > 通过诊断测验评估学生技能——生成个性化8周学习路径，含资源、里程碑和检查点。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/169-ai-learning-path-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/task/data-analysis.md
+++ b/docs/zh/use-cases/task/data-analysis.md
@@ -6,7 +6,7 @@ AI驱动的数据分析、报告、审计和财务智能用例。
 
 > 8分钟生成客户会议简报，多源情报汇聚，高管画像深入。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/019-ai-client-research-brief.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -156,7 +156,7 @@ COCO的AI Client Research Brief在几分钟内为每次客户会议提供全面�
 
 > 10分钟完成复杂报价计算，自动匹配折扣规则和审批流程。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/020-ai-quote-calculator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -319,7 +319,7 @@ COCO的AI Quote Calculator将报价流程从手动、易出错的工作流转变
 
 > 2小时筛选500份简历，替代3天人工筛选。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/025-ai-resume-screener.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -472,7 +472,7 @@ COCO的AI Resume Screener对每份申请进行深度、一致的分析，对照�
 
 > 费用报告即时审核，合规自动通过，异常自动标记。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/029-ai-expense-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -628,7 +628,7 @@ COCO的AI Expense Auditor提供100%的审计覆盖和一致的政策执行。
 
 > 3小时生成多源数据对账的财务报告，替代2天人工。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/030-ai-financial-report-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -766,7 +766,7 @@ COCO的AI Financial Report Generator自动化数据组装、计算和叙事生�
 
 > 实时库存预测，替代每周手动盘点，减少滞销和缺货。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/033-ai-inventory-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -924,7 +924,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 2小时完成供应商评估排名，替代1周人工调研。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/034-ai-vendor-evaluator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1071,7 +1071,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 页面加载从4.7秒优化到0.9秒，3周诊断时间变4小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/036-ai-performance-profiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1177,7 +1177,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 慢查询从12秒优化到0.3秒，云计算成本降低42%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/038-ai-database-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1282,7 +1282,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 统一6渠道23个活动的归因分析，ROAS提升37%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/042-ai-campaign-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1388,7 +1388,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 用户画像创建从6周缩短到2天，细分准确度89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/044-ai-persona-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1494,7 +1494,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 销售预测误差从40%降至8%，成交预测91%准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/045-ai-sales-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1600,7 +1600,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 实时竞品定价监控，响应时间从3周到4小时，用户收入+23%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/047-ai-pricing-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1706,7 +1706,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 合同审查从5天降至45分钟，风险检出率从72%提至99%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/048-ai-contract-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1812,7 +1812,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 100%处理14000条月度反馈，问题发现从3周到24小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/053-ai-sentiment-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1918,7 +1918,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 实时薪酬对标，Offer竞争力从52%提至89%，遗憾离职降35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/057-ai-comp-benchmarker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2024,7 +2024,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 现金流预测准确率从64%提至93%，全年零现金危机。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/060-ai-cash-flow-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2130,7 +2130,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 流程时间从14天降至4天，返工率从31%降至8%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/062-ai-process-miner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2236,7 +2236,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 风险预测84%准确，每年预防$420万损失。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/064-ai-risk-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2342,7 +2342,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 产品反馈分析从2周缩短到2小时，覆盖100%的用户反馈。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/070-ai-product-feedback-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2521,7 +2521,7 @@ COCO的AI产品反馈分析器将这种混乱转变为流畅的智能工作流�
 
 > 销售区域平衡度提升45%，区域间业绩差距缩小60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/073-ai-sales-territory-mapper.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2700,7 +2700,7 @@ COCO的AI销售区域规划器将这种混乱转变为流畅的智能工作流�
 
 > 营销ROI报告生成从3天降至实时，跨渠道归因准确率92%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/079-ai-marketing-roi-dashboard.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2879,7 +2879,7 @@ COCO的AI营销ROI仪表盘将这种混乱转变为流畅的智能工作流。�
 
 > 专利检索从3周缩短到4小时，现有技术覆盖率从60%提升到97%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/081-ai-patent-research-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3058,7 +3058,7 @@ COCO的AI专利研究助手将这种混乱转变为流畅的智能工作流。�
 
 > QA覆盖率从40%提升到92%，回归缺陷减少67%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/083-ai-quality-assurance-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3237,7 +3237,7 @@ COCO的AI质量保证审计器将这种混乱转变为流畅的智能工作流�
 
 > 税务准备时间减少70%，申报错误降低92%，罚款归零。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/085-ai-tax-preparation-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3416,7 +3416,7 @@ COCO的AI税务准备助手将这种混乱转变为流畅的智能工作流。�
 
 > 流失客户挽回率从8%提升到35%，获客成本降低60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/086-ai-customer-win-back-campaigner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3595,7 +3595,7 @@ COCO的AI客户挽回营销器将这种混乱转变为流畅的智能工作流�
 
 > 发票核对时间减少85%，差异检出率从72%提升到99.5%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/088-ai-vendor-invoice-reconciler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3774,7 +3774,7 @@ COCO的AI供应商发票核对器将这种混乱转变为流畅的智能工作�
 
 > 冲刺规划会议从3小时缩短到45分钟，交付准确率提升38%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/090-ai-sprint-planning-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3971,7 +3971,7 @@ COCO的AI冲刺规划助手将冲刺规划从主观辩论转变为数据驱动�
 
 > 租赁合同审查从5天降至1小时，隐藏条款识别率提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/091-ai-lease-agreement-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4159,7 +4159,7 @@ COCO的AI租赁合同审查师充当你不知疲倦的租赁分析师，结合�
 
 > 差旅费用合规率从68%提升到97%，差旅开支节省23%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/092-ai-travel-expense-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4358,7 +4358,7 @@ COCO的AI差旅费用优化师管理从预订到报销的整个差旅生命周�
 
 > 董事会报告编制从40小时降至4小时，数据准确率达99.8%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/096-ai-board-report-compiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4575,7 +4575,7 @@ KPI数据（本季度 vs 上季度 vs 计划）：
 
 > 销售异议处理成功率从35%提升到72%，成交周期缩短25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/098-ai-sales-objection-handler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4807,7 +4807,7 @@ COCO的AI销售异议处理器将经验知识转化为可扩展的、始终最�
 
 > 需求预测误差从35%降至8%，库存成本降低28%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/100-ai-demand-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5006,7 +5006,7 @@ COCO的AI需求预测器通过结合先进的机器学习和外部信号集成�
 
 > 客户健康度评估覆盖率从20%提升到100%，流失预警准确率87%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/102-ai-customer-health-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5219,7 +5219,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 提取20+可比房产数据，调整位置和条件因素，5分钟生成市场估值报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/108-ai-property-valuation-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5231,7 +5231,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 结合气象数据、土壤报告和历史产量，以8%以内的误差预测收获量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/115-ai-crop-yield-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5243,7 +5243,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 关联1000+电网节点传感器数据——2分钟定位故障根因，替代原来的2小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/116-ai-grid-outage-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5255,7 +5255,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 计算每道菜品的食材成本占比——建议价格调整和替代方案以达到30%毛利目标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/125-ai-menu-cost-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5267,7 +5267,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 处理射频传播数据、地形图和分区规则——20分钟按覆盖潜力对50个候选站点排名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/134-ai-5g-site-survey-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5279,7 +5279,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 将专利组合与竞争对手申请对比——跨300+专利识别空白领域和潜在侵权风险。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/138-ai-ip-portfolio-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5291,7 +5291,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 处理市政厅和调查中的1万+市民评论——将主题、情绪和紧急程度聚类为可操作简报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/144-ai-constituent-feedback-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5303,7 +5303,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 处理8个平台的流媒体数据——30分钟按分成协议精确计算5万首曲目的艺人版税。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/148-ai-royalty-calculator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5315,7 +5315,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 收集50+同行运营KPI——排名客户绩效并识别达到上四分位的改进目标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/157-ai-benchmarking-analyst.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5327,7 +5327,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 从上传的平面图提取房间尺寸、计算可用面积并标记违规——仅需2分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/166-ai-floor-plan-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5339,7 +5339,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 基于公开数据构建TAM/SAM/SOM模型——20分钟生成自下而上和自上而下的估算及数据来源。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/174-ai-market-sizing-modeler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5351,7 +5351,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 每月对比200个预算项的实际支出——突出超过5%的差异并提供下钻分析。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/176-ai-budget-variance-analyst.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5363,7 +5363,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 解读50个田区的pH值、营养和有机质化验结果——推荐施肥方案及成本估算。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/177-ai-soil-health-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5375,7 +5375,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 处理500辆车的GPS、油耗和驾驶行为数据——生成周度评分卡，发现每年$8万节油机会。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/182-ai-fleet-telematics-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5387,7 +5387,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 运行100个定价场景结合弹性曲线和竞品数据——推荐使LTV最大化20%的层级结构。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/189-ai-pricing-strategy-modeler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5399,7 +5399,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 对保险账簿运行500个死亡率和发病率情景——30分钟压力测试准备金并突出资金不足环节。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/194-ai-actuarial-scenario-runner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5411,7 +5411,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 提取30笔近期成交，调整特征和时间因素——生成含照片和定价依据的客户报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/202-ai-comparative-market-analysis.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/task/process-automation.md
+++ b/docs/zh/use-cases/task/process-automation.md
@@ -6,7 +6,7 @@ AI驱动的工作流自动化、系统集成和运营效率用例。
 
 > 自动审查每个PR：Bug、安全漏洞、性能问题——15分钟出完整报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/005-ai-code-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -146,7 +146,7 @@ PR信息：
 
 > 读取源码，30分钟生成包含边界条件的完整测试。覆盖率从34%提升到89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/006-ai-test-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -322,7 +322,7 @@ Bug描述：[描述bug]
 
 > 实时监控每次部署，90秒检测异常，自动回滚。MTTR从47分钟降至2分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/007-ai-deploy-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -493,7 +493,7 @@ COCO的AI Deploy Monitor作为智能层叠加在你现有的监控基础设施�
 
 > 粘贴错误日志，AI从症状追溯到根因，提供可直接应用的修复diff。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/009-ai-debug-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -692,7 +692,7 @@ COCO的AI Debug Assistant作为一个高级debug伙伴，读过你的整个代�
 
 > 通话、邮件、会议自动同步CRM，45分钟/天数据录入变为0。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/016-ai-crm-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -850,7 +850,7 @@ Pipeline数据：
 
 > 工单自动分类路由，5分钟/单变为即时处理。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/021-ai-ticket-classifier.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1005,7 +1005,7 @@ SLA层级：[按优先级列出你的SLA要求]
 
 > 自动识别VIP客户异常，30%漏检降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/024-ai-vip-escalation.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1162,7 +1162,7 @@ CSM：[姓名]
 
 > 3分钟完成面试排期，自动协调多方日历。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/027-ai-interview-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1320,7 +1320,7 @@ COCO的AI Interview Scheduler自动化从初始可用性到确认的整个排期
 
 > 新员工3天完成入职，替代传统2周流程。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/028-ai-onboarding-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1498,7 +1498,7 @@ COCO的AI Onboarding Assistant协调从offer接受到90天里程碑的整个入�
 
 > 30秒处理一张发票：提取、匹配、路由全自动。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/031-ai-invoice-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1665,7 +1665,7 @@ COCO的AI Invoice Processor自动化从接收到付款的整个AP工作流。
 
 > 会议结束即出纪要：转录、摘要、待办分配一步到位。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/032-ai-meeting-notes.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1827,7 +1827,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 230万行遗留代码迁移从8年缩短到14个月，缺陷率从23%降至3%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/035-ai-code-migrator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1933,7 +1933,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 自动管理1847个依赖，23个CVE全部清零，更新成功率94%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/039-ai-dependency-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2039,7 +2039,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 演示准备从4小时降至15分钟，演示转化率从18%提至34%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/046-ai-demo-personalizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2145,7 +2145,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 客服机器人解决率从27%提至78%，训练时间从6个月到2周。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/050-ai-chatbot-trainer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2251,7 +2251,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 培训完成率从23%提至71%，6个月技能差距关闭64%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/056-ai-training-recommender.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2357,7 +2357,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 文档搜索从18分钟降至30秒，错误分类从34%降至3%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/063-ai-document-classifier.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2463,7 +2463,7 @@ COCO的AI Meeting Notes捕获一切、结构化它、并确保跟进。
 
 > 数据录入自动化，准确率从96%提升至99.7%，处理时间减少94%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/065-ai-data-entry-automator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2650,7 +2650,7 @@ COCO的AI数据录入自动化工具连接你现有的文档来源和目标系�
 
 > 邮件处理时间减少73%，优先邮件响应从4.2小时降至23分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/066-ai-email-triage-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2821,7 +2821,7 @@ COCO的AI邮件分诊管理器将这种混乱转变为流畅的智能工作流�
 
 > 会议安排后勤时间减少87%，跨时区会议安排速度提升3倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/067-ai-meeting-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2991,7 +2991,7 @@ COCO的AI会议调度助手将这种混乱转变为流畅的智能工作流。�
 
 > 监管申报准备时间减少78%，合规错误降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/071-ai-regulatory-filing-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3170,7 +3170,7 @@ COCO的AI合规申报助手将这种混乱转变为流畅的智能工作流。�
 
 > 工单误路由减少89%，升级解决时间从24小时降至2小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/074-ai-helpdesk-escalation-router.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3349,7 +3349,7 @@ COCO的AI工单升级路由器将这种混乱转变为流畅的智能工作流�
 
 > 数据管道故障检测从小时级降至秒级，数据质量问题减少91%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/075-ai-data-pipeline-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3528,7 +3528,7 @@ COCO的AI数据管道监控器将这种混乱转变为流畅的智能工作流�
 
 > 本地化周期从6周缩短到3天，翻译一致性提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/076-ai-localization-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3707,7 +3707,7 @@ COCO的AI本地化管理器将这种混乱转变为流畅的智能工作流。�
 
 > 供应链可视性从30%提升到95%，中断响应时间减少76%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/077-ai-supply-chain-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3886,7 +3886,7 @@ COCO的AI供应链追踪器将这种混乱转变为流畅的智能工作流。�
 
 > 客户入驻时间从3周缩短到3天，首月激活率提升55%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/078-ai-customer-onboarding-guide.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4065,7 +4065,7 @@ COCO的AI客户入驻引导助手将这种混乱转变为流畅的智能工作�
 
 > 事件响应时间从45分钟降至8分钟，MTTR减少73%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/080-ai-incident-response-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4244,7 +4244,7 @@ COCO的AI事件响应协调器将这种混乱转变为流畅的智能工作流�
 
 > 员工离职流程从2周缩短到1天，权限撤销遗漏降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/082-ai-employee-offboarding-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4423,7 +4423,7 @@ COCO的AI员工离职管理器将这种混乱转变为流畅的智能工作流�
 
 > 税务准备时间减少70%，申报错误降低92%，罚款归零。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/085-ai-tax-preparation-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4602,7 +4602,7 @@ COCO的AI税务准备助手将这种混乱转变为流畅的智能工作流。�
 
 > 发票核对时间减少85%，差异检出率从72%提升到99.5%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/088-ai-vendor-invoice-reconciler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4781,7 +4781,7 @@ COCO的AI供应商发票核对器将这种混乱转变为流畅的智能工作�
 
 > 冲刺规划会议从3小时缩短到45分钟，交付准确率提升38%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/090-ai-sprint-planning-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4978,7 +4978,7 @@ COCO的AI冲刺规划助手将冲刺规划从主观辩论转变为数据驱动�
 
 > 差旅费用合规率从68%提升到97%，差旅开支节省23%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/092-ai-travel-expense-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5177,7 +5177,7 @@ COCO的AI差旅费用优化师管理从预订到报销的整个差旅生命周�
 
 > 合规培训完成率从52%提升到96%，逾期培训降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/097-ai-compliance-training-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5399,7 +5399,7 @@ COCO的AI合规培训追踪器将合规培训从被动、人力密集的流程�
 
 > IT资产可见性从45%提升到99%，影子IT发现率提升10倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/099-ai-it-asset-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5632,7 +5632,7 @@ COCO的AI IT资产管理器为您组织中的每项技术资产创建全面、�
 
 > 跨部门工作流自动化率从15%提升到78%，处理时间减少65%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/103-ai-workflow-automator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5838,7 +5838,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 3分钟扫描50页合同——签字前标记风险条款、缺失条款和异常条件。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/105-ai-contract-analyzer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5850,7 +5850,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 90秒数字化患者入院表——将人口统计、保险信息和病史自动录入电子病历系统。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/106-ai-patient-intake-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5862,7 +5862,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 跨部门追踪200+许可证申请——提前7天标记缺失文件和临近截止日期。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/114-ai-permit-application-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5874,7 +5874,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 对照保单条款审核理赔申请——自动通过简单案件，处理时间从5天缩短到4小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/117-ai-claims-adjuster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5886,7 +5886,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 分析拣货频率和订单模式——重新设计仓库分区，平均拣货时间缩短35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/124-ai-warehouse-layout-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5898,7 +5898,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 分析100+设备的振动、温度和运行数据——在故障前安排维护，停机时间减少40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/126-ai-predictive-maintenance-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5910,7 +5910,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 对5000+捐赠者进行参与度、捐赠历史和能力评分——优先联络以提升续捐率25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/128-ai-donor-engagement-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5922,7 +5922,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 结合土壤湿度传感器、天气预报和作物需求——优化灌溉计划，减少30%用水量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/130-ai-irrigation-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5934,7 +5934,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 分析理赔历史、风险画像和市场费率——到期前30天推荐最优续保方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/132-ai-policy-renewal-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5946,7 +5946,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 规划每日80个站点的最优配送路线——综合交通、时间窗和车辆容量，燃油成本降低20%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/139-ai-route-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5958,7 +5958,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 将BOM与5000+供应商目录交叉验证——3分钟发现停产零件并建议替代方案以降低成本。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/141-ai-bill-of-materials-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5970,7 +5970,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 根据技能、空闲时间和历史表现将500名志愿者匹配到30个活动岗位——自动发送确认。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/143-ai-volunteer-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5982,7 +5982,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 跨3个系统同步OEM零件编号、定价和适配数据——每晚核对保持8万SKU准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/150-ai-parts-catalog-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -5994,7 +5994,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 阅读临床记录分配ICD-10和CPT编码——首次准确率96%，拒付率降低40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/151-ai-medical-coding-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6006,7 +6006,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 从自然语言中提取事故细节——生成符合OSHA标准的报告，包含根因分析和纠正措施。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/156-ai-safety-incident-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6018,7 +6018,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 对照豁免标准审查信息公开请求——编辑敏感内容并起草回复，处理周期从30天缩短到5天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/159-ai-foia-request-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6030,7 +6030,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 映射新旧电子病历系统间的字段——转换50万条患者记录，带验证检查和错误日志。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/168-ai-ehr-data-migrator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6042,7 +6042,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 识别保管人、发送保全通知、追踪确认并监控合规——管理50+活跃保全，零遗漏截止日期。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/170-ai-litigation-hold-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6054,7 +6054,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 在20个月台协调进出车辆——通过实时时段优化将停留时间缩短45%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/171-ai-cross-dock-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6066,7 +6066,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 根据退房时间、特殊需求和距离将80间房分配给15名清洁员——周转时间缩短25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/172-ai-housekeeping-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6078,7 +6078,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 排序200个生产订单以最小化换线时间——在满足所有交期的同时提升15%产量。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/173-ai-production-batch-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6090,7 +6090,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 跨30个地区追踪1万+作品的授权窗口——权利到期前60天提醒续约决策。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/180-ai-content-rights-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6102,7 +6102,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 按生命周期阶段细分50万订户——在入网、升级和留存节点触发个性化营销。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/181-ai-subscriber-lifecycle-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6114,7 +6114,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 对比5家PBM的药品目录方案——找到节省22%药品支出的等效替代品，不影响疗效。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/183-ai-pharmacy-benefit-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6126,7 +6126,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 建模人口趋势、申请漏斗和竞争动态——以3%以内误差预测下一年招生人数。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/184-ai-enrollment-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6138,7 +6138,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 将货物归入HS编码、计算关税并预填报关单——清关时间从48小时缩短到6小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/186-ai-customs-declaration-filer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6150,7 +6150,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 基于需求、活动和竞争定价动态调整房价——比静态定价提升12% RevPAR。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/187-ai-revenue-management-optimizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6162,7 +6162,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 实时监控50张控制图——在产生废品前3个班次检测到超差趋势，自动触发警报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/188-ai-spc-chart-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6174,7 +6174,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 按25项加权标准评分30份供应商投标——45分钟生成比较矩阵并筛选前3名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/191-ai-procurement-bid-evaluator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6186,7 +6186,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 筛选在线潜客、匹配车型偏好并预约试驾——以确认预约填满90%可用时段。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/197-ai-test-drive-scheduler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6198,7 +6198,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 提取信用、就业和租赁历史——3分钟生成符合公平住房法的带风险评分筛查报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/199-ai-tenant-screening-processor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6210,7 +6210,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 从Jira、Salesforce等6个工具同步关键结果——生成周度OKR评分卡显示红黄绿状态。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/200-ai-okr-progress-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6222,7 +6222,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 10分钟内生成12周课程大纲——包含学习目标、作业设计和评分标准。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/107-ai-curriculum-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6234,7 +6234,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 在6个平台上为客人评论撰写个性化回复——每条30秒，完美匹配品牌语调。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/110-ai-hotel-review-responder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6246,7 +6246,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 分析产线照片和传感器数据——产品出厂前以98.5%准确率捕捉缺陷。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/111-ai-production-defect-detector.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6258,7 +6258,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 60秒生成符合管辖区要求的保密协议——根据交易背景定制范围、期限和例外条款。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/123-ai-nda-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6270,7 +6270,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 提取公开文件、新闻、诉讼记录和财务数据——2小时完成尽职调查报告，替代原来的2周。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/127-ai-due-diligence-compiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6282,7 +6282,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 从12个数据源汇总范围1-3排放数据——生成符合GHG协议的审计就绪碳排放报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/131-ai-carbon-footprint-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6294,7 +6294,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 将客户偏好与15家经销商库存匹配——推荐最佳车型并估算置换价格。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/135-ai-dealership-inventory-matcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6306,7 +6306,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 分析预订历史和客人画像——推荐个性化房间升级和套餐，RevPAR提升18%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/140-ai-guest-upsell-recommender.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6318,7 +6318,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 将原始分析转化为麦肯锡风格幻灯片——25分钟构建30张包含图表、关键发现和建议的PPT。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/142-ai-management-consulting-deck-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6330,7 +6330,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 将运费与200+航线的市场数据对标——发现平均每批货物可节省12%的机会。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/154-ai-freight-rate-negotiator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6342,7 +6342,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 协调300人活动的场地、餐饮、音视频和人员——15分钟生成时间线、检查单和供应商订单。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/155-ai-event-logistics-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6354,7 +6354,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 按评分标准批改研究论文——2分钟提供论证、证据和写作质量的段落级反馈。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/163-ai-research-paper-grader.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6366,7 +6366,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 通过诊断测验评估学生技能——生成个性化8周学习路径，含资源、里程碑和检查点。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/169-ai-learning-path-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6378,7 +6378,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 策划500人晚宴——在一个面板管理RSVP、座位安排、拍卖目录和赞助方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/175-ai-fundraising-event-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6390,7 +6390,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 监控现货价格、天气预报和需求曲线——建议次日能源市场的最优买卖时间窗口。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/178-ai-energy-trading-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -6402,7 +6402,7 @@ COCO的AI工作流自动化器采用根本不同的自动化方法——从智�
 
 > 按观看历史、人口统计和互动数据聚类200万观众——构建12个可操作画像用于定向内容策略。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/195-ai-audience-segmentation-engine.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/task/research-monitoring.md
+++ b/docs/zh/use-cases/task/research-monitoring.md
@@ -6,7 +6,7 @@ AI驱动的市场调研、竞品分析、监控和趋势追踪用例。
 
 > 自动汇聚行业资讯，5小时/周的人工策展变为30分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/013-ai-newsletter-curator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -158,7 +158,7 @@ COCO的AI Newsletter Curator自动化Newsletter制作中劳动密集的部分，
 
 > 实时追踪竞品动态，2天调研变为1小时自动化输出。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/014-ai-competitive-copywriter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -333,7 +333,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 一天调研200个线索，自动从LinkedIn、企查查抓取并打分。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/015-ai-lead-researcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -517,7 +517,7 @@ LinkedIn URL：[URL]
 
 > 8分钟生成客户会议简报，多源情报汇聚，高管画像深入。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/019-ai-client-research-brief.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -667,7 +667,7 @@ COCO的AI Client Research Brief在几分钟内为每次客户会议提供全面�
 
 > 自动识别VIP客户异常，30%漏检降至0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/024-ai-vip-escalation.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -824,7 +824,7 @@ CSM：[姓名]
 
 > 费用报告即时审核，合规自动通过，异常自动标记。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/029-ai-expense-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -980,7 +980,7 @@ COCO的AI Expense Auditor提供100%的审计覆盖和一致的政策执行。
 
 > 实时库存预测，替代每周手动盘点，减少滞销和缺货。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/033-ai-inventory-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1138,7 +1138,7 @@ COCO的AI Inventory Forecaster将历史分析与实时信号检测相结合，�
 
 > 2小时完成供应商评估排名，替代1周人工调研。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/034-ai-vendor-evaluator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1285,7 +1285,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 持续安全扫描，误报率从91%降至8%，修复时间从38天到4天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/037-ai-security-scanner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1391,7 +1391,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 品牌危机发现时间从72小时降至11分钟，覆盖率从10%到97%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/040-ai-brand-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1497,7 +1497,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 达人审核从15小时降至20分钟，投放ROI从0.8倍提升到4.2倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/041-ai-influencer-finder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1603,7 +1603,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 客户流失预测87%准确，挽回率从12%提至41%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/049-ai-churn-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1709,7 +1709,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > Bug分诊从6小时/Sprint降至30分钟，严重Bug修复从14天到3天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/051-ai-bug-prioritizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1815,7 +1815,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > SLA违约从12次/季降至1次/季，罚金从$20万/年降至$1.5万/年。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/052-ai-sla-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1921,7 +1921,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 员工调查响应率从31%提至82%，离职预测89%准确。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/055-ai-employee-pulse.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2027,7 +2027,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 交易合规检查覆盖率从5%到100%，审计准备从6周到3天。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/061-ai-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2133,7 +2133,7 @@ COCO的AI Vendor Evaluator标准化、加速并深化供应商评估流程。
 
 > 客户流失预警提前30天发现，挽回率从15%提升到42%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/069-ai-customer-success-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2312,7 +2312,7 @@ COCO的AI客户成功监控器将这种混乱转变为流畅的智能工作流�
 
 > 数据管道故障检测从小时级降至秒级，数据质量问题减少91%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/075-ai-data-pipeline-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2491,7 +2491,7 @@ COCO的AI数据管道监控器将这种混乱转变为流畅的智能工作流�
 
 > 供应链可视性从30%提升到95%，中断响应时间减少76%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/077-ai-supply-chain-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2670,7 +2670,7 @@ COCO的AI供应链追踪器将这种混乱转变为流畅的智能工作流。�
 
 > 营销ROI报告生成从3天降至实时，跨渠道归因准确率92%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/079-ai-marketing-roi-dashboard.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2849,7 +2849,7 @@ COCO的AI营销ROI仪表盘将这种混乱转变为流畅的智能工作流。�
 
 > 事件响应时间从45分钟降至8分钟，MTTR减少73%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/080-ai-incident-response-coordinator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3028,7 +3028,7 @@ COCO的AI事件响应协调器将这种混乱转变为流畅的智能工作流�
 
 > 竞品动态检测从每月一次变为实时，战略响应速度提升5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/084-ai-competitive-intelligence-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3207,7 +3207,7 @@ COCO的AI竞争情报追踪器将这种混乱转变为流畅的智能工作流�
 
 > 品牌提及监测覆盖率从15%提升到96%，危机响应时间降至15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/089-ai-social-listening-agent.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3406,7 +3406,7 @@ COCO的AI社交媒体监听助手作为7×24小时品牌情报系统运作，覆
 
 > 调研回复率从3%提升到28%，可操作洞察产出量增加5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/094-ai-customer-survey-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3651,7 +3651,7 @@ COCO的AI客户调研设计师将调查从粗糙的工具转变为精准的反�
 
 > 合规培训完成率从52%提升到96%，逾期培训降至接近0%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/097-ai-compliance-training-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3873,7 +3873,7 @@ COCO的AI合规培训追踪器将合规培训从被动、人力密集的流程�
 
 > IT资产可见性从45%提升到99%，影子IT发现率提升10倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/099-ai-it-asset-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4106,7 +4106,7 @@ COCO的AI IT资产管理器为您组织中的每项技术资产创建全面、�
 
 > 需求预测误差从35%降至8%，库存成本降低28%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/100-ai-demand-forecaster.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4305,7 +4305,7 @@ COCO的AI需求预测器通过结合先进的机器学习和外部信号集成�
 
 > 客户健康度评估覆盖率从20%提升到100%，流失预警准确率87%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/102-ai-customer-health-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4518,7 +4518,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 跨承运商监控500+在途货物——在延误影响交付前4小时发出预警。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/109-ai-shipment-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4530,7 +4530,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 分析50+基站流量模式——在拥堵发生前3个月推荐扩容方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/119-ai-network-capacity-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4542,7 +4542,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 每日扫描NHTSA数据库和服务公告——将召回信息匹配车队库存并生成行动方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/120-ai-vehicle-recall-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4554,7 +4554,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 将患者记录与40+试验标准匹配——筛选合格候选人速度比人工快10倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/121-ai-clinical-trial-screener.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4566,7 +4566,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 汇总200名学生的成绩、出勤和参与数据——每周标记高风险学生并建议干预措施。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/122-ai-student-progress-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4578,7 +4578,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 同时搜索15个政府数据库——5分钟编撰房产、法院和商业记录。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/129-ai-public-records-researcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4590,7 +4590,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 扫描访问日志、加密配置和数据流——15分钟识别HIPAA违规并生成整改任务。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/136-ai-hipaa-compliance-auditor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4602,7 +4602,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 将学生提交内容与1000万+来源和AI生成模式对比——标记可疑段落并给出置信度评分。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/137-ai-plagiarism-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4614,7 +4614,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 分析作物照片和本地病虫害数据库——以95%准确率识别虫害并推荐治疗方案。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/145-ai-pest-detection-advisor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4626,7 +4626,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 实时追踪2000+太阳能板产出——10分钟内检测衰减、遮挡问题和逆变器故障。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/146-ai-solar-panel-performance-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4638,7 +4638,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 对照50项风险因素评估申请人数据——8分钟生成带置信度评分的核保建议。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/147-ai-underwriting-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4650,7 +4650,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 基于30+行为信号对10万订户评分——提前45天以87%准确率识别可能流失客户。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/149-ai-churn-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4662,7 +4662,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 将课程项目与150+认证标准对照——突出差距并自动生成证据文档。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/152-ai-accreditation-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4674,7 +4674,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 搜索USPTO、EUIPO等20+商标数据库——10分钟交付带风险评分的全面冲突报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/153-ai-trademark-conflict-searcher.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4686,7 +4686,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 跨地缘政治、财务和天气风险因素监控300家供应商——每日生成带缓解措施的风险评分卡。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/160-ai-supply-chain-risk-scorer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4698,7 +4698,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 映射新旧版本间200+ API端点——生成包含破坏性变更警告和代码示例的迁移指南。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/161-ai-api-migration-planner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4710,7 +4710,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 每日监控SEC、FINRA和12个全球监管机构——将新规映射到合规义务，提前48小时预警。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/164-ai-regulatory-change-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4722,7 +4722,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 跨5家承运商追踪每日2000次配送——自动就延误联系客户并建议重新配送时间。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/165-ai-last-mile-delivery-tracker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4734,7 +4734,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 分析10万条理赔记录——以92%精度识别可疑聚类和伪造事故指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/179-ai-fraud-pattern-detector.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4746,7 +4746,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 追踪1000头牲畜的采食量、运动和体温——在可见症状出现前48小时检测疾病指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/192-ai-livestock-health-monitor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4758,7 +4758,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 审查80页购电协议——10分钟标记价格升级条款、限电风险和不利条款。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/193-ai-power-purchase-agreement-reviewer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4770,7 +4770,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 分析网络告警和客户投诉模式——提前6小时预测工单高峰以便客服增加人手。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/196-ai-service-ticket-predictor.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4782,7 +4782,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 每晚扫描15个仓库的2000个依赖——按可利用性优先排序CVE并自动生成升级PR。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/198-ai-dependency-vulnerability-scanner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4794,7 +4794,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 绘制200名医师的转诊模式——识别高价值关系缺口和拓展优先级。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/201-ai-referral-network-mapper.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4806,7 +4806,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 从8个部门更新汇编董事会资料包——将财务、战略和表决事项格式化为品牌化40页PPT。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/203-ai-board-meeting-prep-assistant.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4818,7 +4818,7 @@ COCO的AI客户健康评分器用全面的预测系统替代简单的手动健�
 
 > 按WCAG 2.2 AA标准扫描Web应用——标记200+检查点并提供修复建议和优先级排名。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/204-ai-accessibility-compliance-checker.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 

--- a/docs/zh/use-cases/task/writing-content.md
+++ b/docs/zh/use-cases/task/writing-content.md
@@ -6,7 +6,7 @@ AI驱动的内容创作、文案写作和文档编写用例。
 
 > 从代码库自动生成并同步API文档，多语言示例，零偏差。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/008-ai-api-doc-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -191,7 +191,7 @@ API概述：[简要描述API功能]
 
 > 20分钟产出一篇SEO优化的高质量文章，关键词研究到终稿一站式完成。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/010-ai-seo-content-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -396,7 +396,7 @@ COCO的AI SEO Content Writer将内容创作流水线从一个串行的、劳动�
 
 > 一次输入，全平台适配发布。每天3小时社媒运营缩减到15分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/011-ai-social-media-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -583,7 +583,7 @@ COCO的AI Social Media Manager作为社交媒体团队的力量倍增器，处�
 
 > 10分钟生成200个A/B变体广告文案，数据驱动迭代优化。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/012-ai-ad-copy-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -792,7 +792,7 @@ COCO的AI Ad Copy Generator专为效果营销构建，理解各平台付费广�
 
 > 自动汇聚行业资讯，5小时/周的人工策展变为30分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/013-ai-newsletter-curator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -944,7 +944,7 @@ COCO的AI Newsletter Curator自动化Newsletter制作中劳动密集的部分，
 
 > 实时追踪竞品动态，2天调研变为1小时自动化输出。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/014-ai-competitive-copywriter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1119,7 +1119,7 @@ COCO的AI Competitive Copywriter弥合竞品情报和面向收入的文案之间
 
 > 15分钟生成定制化方案书，基于客户需求自动匹配。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/017-ai-proposal-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1292,7 +1292,7 @@ RFP问题/要求：
 
 > 2分钟生成个性化跟进邮件，基于会议上下文和客户行为。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/018-ai-follow-up-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1465,7 +1465,7 @@ COCO的AI Follow-up Writer通过生成及时、有上下文的跟进沟通确保
 
 > 1小时生成50篇知识库文章，从工单和对话自动提取。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/022-ai-knowledge-base-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1623,7 +1623,7 @@ COCO的AI Knowledge Base Builder将已解决的客服工单转化为已发布的
 
 > AI一键支持15+语言客服，替代5个翻译人员。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/023-ai-multi-language-support.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1783,7 +1783,7 @@ COCO的AI Multi-Language Support提供母语质量的多语言客户服务，无
 
 > 10分钟生成无偏见、SEO优化的职位描述。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/026-ai-job-description-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -1958,7 +1958,7 @@ COCO的AI Job Description Writer创建引人注目的、包容的、高效的职
 
 > 内容规划从每周8小时降至45分钟，发布一致性从62%到96%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/043-ai-content-calendar.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2064,7 +2064,7 @@ COCO的AI Job Description Writer创建引人注目的、包容的、高效的职
 
 > 工单分流+45%，FAQ覆盖从120篇到850+篇，每周节省23小时。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/054-ai-faq-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2170,7 +2170,7 @@ COCO的AI Job Description Writer创建引人注目的、包容的、高效的职
 
 > 绩效评审撰写从40小时降至6小时，可操作反馈从24%提至87%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/058-ai-review-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2276,7 +2276,7 @@ COCO的AI Job Description Writer创建引人注目的、包容的、高效的职
 
 > 847份政策文档更新从6周缩短到4天，合规风险降89%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/059-ai-policy-updater.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2382,7 +2382,7 @@ COCO的AI Job Description Writer创建引人注目的、包容的、高效的职
 
 > 法律文档起草从5天缩短到2小时，合规风险降低85%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/068-ai-legal-document-drafter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2561,7 +2561,7 @@ COCO的AI法律文档起草助手将这种混乱转变为流畅的智能工作�
 
 > 项目状态报告编写从4小时降至15分钟，实时数据自动聚合。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/072-ai-project-status-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2740,7 +2740,7 @@ COCO的AI项目状态报告生成器将这种混乱转变为流畅的智能工�
 
 > 本地化周期从6周缩短到3天，翻译一致性提升到98%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/076-ai-localization-manager.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -2919,7 +2919,7 @@ COCO的AI本地化管理器将这种混乱转变为流畅的智能工作流。�
 
 > 流失客户挽回率从8%提升到35%，获客成本降低60%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/086-ai-customer-win-back-campaigner.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3098,7 +3098,7 @@ COCO的AI客户挽回营销器将这种混乱转变为流畅的智能工作流�
 
 > 技术文档编写从3天降至2小时，文档与代码同步率99%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/087-ai-technical-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3286,7 +3286,7 @@ SDK语言：[语言]
 
 > 职位广告点击率提升65%，优质候选人申请量增加40%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/093-ai-recruitment-marketing-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3465,7 +3465,7 @@ COCO的AI招聘营销文案助手将这种混乱转变为流畅的智能工作�
 
 > 调研回复率从3%提升到28%，可操作洞察产出量增加5倍。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/094-ai-customer-survey-designer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3710,7 +3710,7 @@ COCO的AI客户调研设计师将调查从粗糙的工具转变为精准的反�
 
 > 发版说明编写从3-4小时降至5分钟，功能采用率提升35%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/095-ai-release-notes-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -3974,7 +3974,7 @@ Git日志：
 
 > 董事会报告编制从40小时降至4小时，数据准确率达99.8%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/096-ai-board-report-compiler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4191,7 +4191,7 @@ KPI数据（本季度 vs 上季度 vs 计划）：
 
 > 销售异议处理成功率从35%提升到72%，成交周期缩短25%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/098-ai-sales-objection-handler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4423,7 +4423,7 @@ COCO的AI销售异议处理器将经验知识转化为可扩展的、始终最�
 
 > 演示文稿制作从15小时降至1小时，客户定制度提升300%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/101-ai-pitch-deck-builder.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4628,7 +4628,7 @@ COCO的AI演示文稿构建器将演示创建从手动、耗时的苦差事转�
 
 > RFP响应时间从40小时降至8小时，中标率从5%提升到18%。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/104-ai-rfp-response-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4859,7 +4859,7 @@ RFP表现数据（过去12个月）：
 
 > 15分钟将市场数据、财务信息和竞争情报综合成10页战略简报。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/112-ai-strategy-brief-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4871,7 +4871,7 @@ RFP表现数据（过去12个月）：
 
 > 根据资助方要求撰写拨款申请——20分钟生成预算、时间表和影响力指标。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/113-ai-grant-proposal-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4883,7 +4883,7 @@ RFP表现数据（过去12个月）：
 
 > 阅读120页剧本生成专业评审——8分钟完成剧情概要、角色分析和市场适配度评估。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/118-ai-script-coverage-reader.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4895,7 +4895,7 @@ RFP表现数据（过去12个月）：
 
 > 转录60分钟节目，提取关键引用，4分钟生成带时间戳的SEO优化节目笔记。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/133-ai-podcast-show-notes-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4907,7 +4907,7 @@ RFP表现数据（过去12个月）：
 
 > 从8个数据源汇总项目数据——20分钟生成包含可视化和成果指标的资助方报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/158-ai-impact-measurement-reporter.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4919,7 +4919,7 @@ RFP表现数据（过去12个月）：
 
 > 将20页患者病历浓缩为结构化1页摘要——突出活跃问题、用药和待处理医嘱。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/162-ai-clinical-notes-summarizer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4931,7 +4931,7 @@ RFP表现数据（过去12个月）：
 
 > 将6个部门数据综合为2页周一晨报——KPI、风险、待决事项，仅需5分钟。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/167-ai-executive-briefing-generator.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4943,7 +4943,7 @@ RFP表现数据（过去12个月）：
 
 > 从10个部门收集ESG指标——2小时内起草符合TCFD和GRI标准的披露文件并验证数据。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/185-ai-esg-disclosure-writer.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 
@@ -4955,7 +4955,7 @@ RFP表现数据（过去12个月）：
 
 > 提取财务、项目成果和捐赠数据——3小时汇编包含图表和叙述的印刷就绪年度报告。
 
-::: details 🎬 Watch Demo Video
+::: details 🎬 观看演示视频
 
 <video controls src="/videos/cn/190-ai-annual-report-assembler.mp4" style="width: 100%; max-width: 480px; max-height: 400px; border-radius: 8px; margin: 0.5rem 0 1rem;"></video>
 


### PR DESCRIPTION
## Summary
- Replace "🎬 Watch Demo Video" → "🎬 观看演示视频" in all 42 ZH use-case files (631 instances)
- EN pages unchanged

## Test plan
- [ ] Verify ZH role pages show "🎬 观看演示视频" instead of English label