### PR TITLE
fix: correct header and footer URLs

### DIFF
--- a/docs/.vitepress/theme/CocoFooter.vue
+++ b/docs/.vitepress/theme/CocoFooter.vue
@@ -12,9 +12,9 @@ const columns = computed(() => {
       {
         title: '产品',
         links: [
-          { text: 'Agent Cloud', href: 'https://coco.xyz' },
+          { text: 'Agent Cloud', href: 'https://coco.xyz/#pricing' },
           { text: 'Zylos', href: 'https://github.com/zylos-ai' },
-          { text: 'HxA Suite', href: 'https://github.com/hxa-k' },
+          { text: 'HxA Suite', href: 'https://github.com/coco-xyz' },
         ],
       },
       {
@@ -45,9 +45,9 @@ const columns = computed(() => {
     {
       title: 'Products',
       links: [
-        { text: 'Agent Cloud', href: 'https://coco.xyz' },
+        { text: 'Agent Cloud', href: 'https://coco.xyz/#pricing' },
         { text: 'Zylos', href: 'https://github.com/zylos-ai' },
-        { text: 'HxA Suite', href: 'https://github.com/hxa-k' },
+        { text: 'HxA Suite', href: 'https://github.com/coco-xyz' },
       ],
     },
     {

--- a/docs/.vitepress/theme/CocoHeader.vue
+++ b/docs/.vitepress/theme/CocoHeader.vue
@@ -12,7 +12,7 @@ const navItems = computed(() => {
   const isZh = lang.value === 'zh-CN'
   return [
     { text: isZh ? '用例' : 'Use Cases', link: isZh ? '/zh/use-cases/' : '/use-cases/' },
-    { text: isZh ? '定价' : 'Pricing', link: 'https://coco.xyz/pricing', external: true },
+    { text: isZh ? '定价' : 'Pricing', link: 'https://coco.xyz/#pricing', external: true },
     { text: 'Labs', link: 'https://labs.coco.xyz', external: true },
     { text: isZh ? '文档' : 'Docs', link: isZh ? '/zh/' : '/', active: true },
   ]


### PR DESCRIPTION
## Summary
- Header nav: Pricing link `coco.xyz/pricing` → `coco.xyz/#pricing`
- Footer: Agent Cloud link `coco.xyz` → `coco.xyz/#pricing`
- Footer: HxA Suite link `github.com/hxa-k` → `github.com/coco-xyz` (org renamed to HxANet)

Fixes #48
Fixes #50

## Scope
URL corrections only — 2 files, 5 lines changed. No content/docs/feature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)