### PR TITLE
feat: enable sitemap generation for docs.coco.xyz

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -8,6 +8,10 @@ export default defineConfig({
   base,
   cleanUrls: true,
 
+  sitemap: {
+    hostname: 'https://docs.coco.xyz'
+  },
+
   srcExclude: [
     '**/use-cases/enterprise-ai-use-cases-research.md',
     '**/use-cases/template.md',


### PR DESCRIPTION
## Summary
- Enable VitePress built-in sitemap generation
- Sets hostname to `https://docs.coco.xyz`
- Sitemap will be auto-generated at `/sitemap.xml` on build

## Context
Part of GEO optimization effort. docs.coco.xyz has 1000+ pages but no sitemap, making it hard for search engines to discover content.

## Test plan
- Build locally and verify `sitemap.xml` is generated in the output directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)