### PR TITLE
fix: CoCo → COCO uppercase + fix card link 404s

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -206,7 +206,7 @@ export default defineConfig({
               text: 'Case Studies',
               items: [
                 { text: 'Capability Showcase', link: '/case-studies/' },
-                { text: 'CoCo CRM — Built by AI, Run by AI', link: '/case-studies/crm' },
+                { text: 'COCO CRM — Built by AI, Run by AI', link: '/case-studies/crm' },
                 { text: 'Social Media & BD Automation', link: '/case-studies/social-media' },
               ]
             },
@@ -334,7 +334,7 @@ export default defineConfig({
               text: '案例研究',
               items: [
                 { text: '能力展示', link: '/zh/case-studies/' },
-                { text: 'CoCo CRM — AI 搭建，AI 运营', link: '/zh/case-studies/crm' },
+                { text: 'COCO CRM — AI 搭建，AI 运营', link: '/zh/case-studies/crm' },
                 { text: '社媒与 BD 自动化', link: '/zh/case-studies/social-media' },
               ]
             },

--- a/docs/.vitepress/theme/CocoHeader.vue
+++ b/docs/.vitepress/theme/CocoHeader.vue
@@ -22,7 +22,7 @@ const navItems = computed(() => {
         {
           title: isZh ? '案例研究' : 'Case Studies',
           items: [
-            { icon: '📊', text: isZh ? 'CoCo CRM' : 'CoCo CRM', desc: isZh ? 'AI 搭建，AI 运营' : 'Built by AI, Run by AI', link: isZh ? '/zh/case-studies/crm' : '/case-studies/crm' },
+            { icon: '📊', text: isZh ? 'COCO CRM' : 'COCO CRM', desc: isZh ? 'AI 搭建，AI 运营' : 'Built by AI, Run by AI', link: isZh ? '/zh/case-studies/crm' : '/case-studies/crm' },
             { icon: '📱', text: isZh ? '社媒自动化' : 'Social Media & BD', desc: isZh ? '两家公司，同一个突破' : 'Two Companies, One Breakthrough', link: isZh ? '/zh/case-studies/social-media' : '/case-studies/social-media' },
           ]
         },

--- a/docs/case-studies/crm.md
+++ b/docs/case-studies/crm.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: "CoCo CRM — Built by AI, Run by AI"
+title: "COCO CRM — Built by AI, Run by AI"
 description: "A complete CRM system designed, built, and operated daily by an AI Agent. Not an assistant — a true digital employee."
 head:
   - - meta
     - property: og:title
-      content: "CoCo CRM — Built by AI, Run by AI"
+      content: "COCO CRM — Built by AI, Run by AI"
   - - meta
     - property: og:description
       content: "A complete CRM system designed, built, and operated daily by an AI Agent."
@@ -795,7 +795,7 @@ head:
 
 <div class="case-hero">
   <div class="hero-text-box">
-    <h1>CoCo CRM<br/><em>Built by AI, Run by AI</em></h1>
+    <h1>COCO CRM<br/><em>Built by AI, Run by AI</em></h1>
     <p class="subtitle">An AI Agent designed a complete 7-sheet CRM in one evening,<br/>then runs it every day — audits, reconciliation, reports, zero human intervention.</p>
     <div class="hero-stats">
       <div class="stat">
@@ -819,7 +819,7 @@ head:
 
 ## Background: <em>Eating Our Own Dog Food</em>
 
-The CoCo team needed to track the full sales pipeline from signup to trial to payment. The traditional approach: buy a SaaS CRM, spend weeks configuring it, then assign someone to maintain it daily.
+The COCO team needed to track the full sales pipeline from signup to trial to payment. The traditional approach: buy a SaaS CRM, spend weeks configuring it, then assign someone to maintain it daily.
 
 They chose a different path — let the AI Agent **Zylos** design and build the entire system directly.
 
@@ -827,7 +827,7 @@ From a requirements description to 7 fully functional spreadsheets: **one evenin
 
 <div class="video-showcase">
   <div class="video-container">
-    <iframe src="https://www.youtube.com/embed/u7o-1GCO89E" title="CoCo CRM Automation Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/u7o-1GCO89E" title="COCO CRM Automation Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
 </div>
 
@@ -988,7 +988,7 @@ From payment notification to CRM update, to team alerts, to follow-up list gener
 
 ## Why This Case Matters
 
-What the CoCo team did with CoCo wasn't about speeding up existing work by a little — it was about bringing to life an operations pipeline that **would never have existed otherwise**, because building it the traditional way would take weeks and real money.
+What the COCO team did with COCO wasn't about speeding up existing work by a little — it was about bringing to life an operations pipeline that **would never have existed otherwise**, because building it the traditional way would take weeks and real money.
 
 This is a simple proof: **If AI can build and continuously operate its own company's CRM from scratch, it can do the same for you.**
 
@@ -997,7 +997,7 @@ This is a simple proof: **If AI can build and continuously operate its own compa
 <div class="blog-meta">
   <div class="blog-meta-item">
     <span class="blog-meta-label">Written by</span>
-    <span class="blog-meta-value">CoCo Team</span>
+    <span class="blog-meta-value">COCO Team</span>
   </div>
   <div class="blog-meta-item">
     <span class="blog-meta-label">Published on</span>
@@ -1008,8 +1008,8 @@ This is a simple proof: **If AI can build and continuously operate its own compa
 <div class="case-section">
   <div class="case-cta">
     <h2>Let AI Build Your Operations System</h2>
-    <p>Like CoCo, start with a single requirements description</p>
-    <a href="https://coco.xyz" class="cta-btn">Try CoCo Free</a>
+    <p>Like COCO, start with a single requirements description</p>
+    <a href="https://coco.xyz" class="cta-btn">Try COCO Free</a>
   </div>
 </div>
 
@@ -1017,7 +1017,7 @@ This is a simple proof: **If AI can build and continuously operate its own compa
   <div class="blog-divider-shell">🐚</div>
   <h3>More Case Studies</h3>
   <div class="blog-related-grid">
-    <a class="blog-related-card" href="/docs/case-studies/social-media">
+    <a class="blog-related-card" href="/case-studies/social-media">
       <div class="blog-related-card-img">📱</div>
       <div class="blog-related-card-body">
         <div class="blog-related-card-label">AI Agent Case Study</div>

--- a/docs/case-studies/social-media.md
+++ b/docs/case-studies/social-media.md
@@ -825,7 +825,7 @@ head:
     <div class="card-label compliance">Tech Compliance</div>
     <h3>A Tech Compliance Firm</h3>
     <div class="card-meta">BD & Marketing Lead · One Person Does Everything</div>
-    <p>Her work spans KOL monitoring, content production, conference BD, and lead management — a scope that typically requires several dedicated roles. She came to CoCo with a specific need.</p>
+    <p>Her work spans KOL monitoring, content production, conference BD, and lead management — a scope that typically requires several dedicated roles. She came to COCO with a specific need.</p>
   </div>
   <div class="company-card">
     <div class="card-label media">Tech Media</div>
@@ -839,7 +839,7 @@ The bottleneck was the same: **more content to produce, more channels to cover, 
 
 <div class="video-showcase">
   <div class="video-container">
-    <iframe src="https://www.youtube.com/embed/jFGNry0BohA" title="CoCo Social Media Automation Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/jFGNry0BohA" title="COCO Social Media Automation Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
 </div>
 
@@ -855,7 +855,7 @@ She sent one message:
   <p>Find which KOLs on a certain project's follow list have posted news recently — in the last two hours</p>
 </div>
 
-CoCo scanned **325 followed accounts**, found **4 recent KOL posts** with direct links, including several top-tier accounts (millions of followers) — **completed in minutes**, no manual Twitter scrolling needed.
+COCO scanned **325 followed accounts**, found **4 recent KOL posts** with direct links, including several top-tier accounts (millions of followers) — **completed in minutes**, no manual Twitter scrolling needed.
 
 That single interaction opened up a much bigger conversation.
 
@@ -865,7 +865,7 @@ That single interaction opened up a much bigger conversation.
 
 ## From Prompt to <em>Complete Operations Model</em>
 
-CoCo worked with her to design a full suite of workflows covering marketing, BD, and sales operations:
+COCO worked with her to design a full suite of workflows covering marketing, BD, and sales operations:
 
 <div class="workflow-section">
   <div class="workflow-block marketing">
@@ -926,7 +926,7 @@ CoCo worked with her to design a full suite of workflows covering marketing, BD,
 
 ## The Media Team's <em>Semi-Automated Publishing</em>
 
-After the Singapore tech media team integrated CoCo:
+After the Singapore tech media team integrated COCO:
 
 - AI digital employees auto-generate **platform-specific content** — Telegram groups, Twitter, Newsletters, each with its own tone
 - Scheduled publishing to communities and social media channels
@@ -939,7 +939,7 @@ After the Singapore tech media team integrated CoCo:
   <div class="publish-flow">
     <div class="publish-source">
       <div class="publish-icon">🤖</div>
-      <div class="publish-label">CoCo AI</div>
+      <div class="publish-label">COCO AI</div>
       <div class="publish-sub">Content Engine</div>
     </div>
     <div class="publish-arrows">
@@ -1002,7 +1002,7 @@ After the Singapore tech media team integrated CoCo:
 
 <div class="insight-block">
   <h3>Two Cases, One Lesson</h3>
-  <p>Whether you're one person running BD and marketing at a compliance firm, or a small media team trying to cover an entire industry, CoCo's solution is the same — <strong>AI handles volume, humans handle strategy</strong>. First to publish, first to reach the right people, wins.</p>
+  <p>Whether you're one person running BD and marketing at a compliance firm, or a small media team trying to cover an entire industry, COCO's solution is the same — <strong>AI handles volume, humans handle strategy</strong>. First to publish, first to reach the right people, wins.</p>
 </div>
 
 </div>
@@ -1010,7 +1010,7 @@ After the Singapore tech media team integrated CoCo:
 <div class="blog-meta">
   <div class="blog-meta-item">
     <span class="blog-meta-label">Written by</span>
-    <span class="blog-meta-value">CoCo Team</span>
+    <span class="blog-meta-value">COCO Team</span>
   </div>
   <div class="blog-meta-item">
     <span class="blog-meta-label">Published on</span>
@@ -1022,7 +1022,7 @@ After the Singapore tech media team integrated CoCo:
   <div class="case-cta">
     <h2>Let AI Take Over Your Content Volume</h2>
     <p>Start with a single message, build a complete operations model</p>
-    <a href="https://coco.xyz" class="cta-btn">Try CoCo Free</a>
+    <a href="https://coco.xyz" class="cta-btn">Try COCO Free</a>
   </div>
 </div>
 
@@ -1030,11 +1030,11 @@ After the Singapore tech media team integrated CoCo:
   <div class="blog-divider-shell">🐚</div>
   <h3>More Case Studies</h3>
   <div class="blog-related-grid">
-    <a class="blog-related-card" href="/docs/case-studies/crm">
+    <a class="blog-related-card" href="/case-studies/crm">
       <div class="blog-related-card-img">📊</div>
       <div class="blog-related-card-body">
         <div class="blog-related-card-label">AI Agent Case Study</div>
-        <div class="blog-related-card-title">CoCo CRM — Built by AI, Run by AI</div>
+        <div class="blog-related-card-title">COCO CRM — Built by AI, Run by AI</div>
         <div class="blog-related-card-desc">A complete CRM system designed, built, and operated daily by an AI Agent.</div>
       </div>
     </a>

--- a/docs/zh/case-studies/crm.md
+++ b/docs/zh/case-studies/crm.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: "CoCo CRM — AI 搭建，AI 运营"
+title: "COCO CRM — AI 搭建，AI 运营"
 description: "一套由 AI Agent 从零设计、搭建并每天自动运营的 CRM 系统。不是辅助工具，是真正的数字员工。"
 head:
   - - meta
     - property: og:title
-      content: "CoCo CRM — Built by AI, Run by AI"
+      content: "COCO CRM — Built by AI, Run by AI"
   - - meta
     - property: og:description
       content: "A complete CRM system designed, built, and operated daily by an AI Agent."
@@ -795,7 +795,7 @@ head:
 
 <div class="case-hero">
   <div class="hero-text-box">
-    <h1>CoCo CRM<br/><em>由 AI 搭建，由 AI 运营</em></h1>
+    <h1>COCO CRM<br/><em>由 AI 搭建，由 AI 运营</em></h1>
     <p class="subtitle">一个 AI Agent 用一个晚上设计了 7 张表的完整 CRM，<br/>然后每天自动运营——巡检、对账、报告，零人工介入。</p>
     <div class="hero-stats">
       <div class="stat">
@@ -819,7 +819,7 @@ head:
 
 ## 背景：<em>用自己的产品运营自己</em>
 
-CoCo 团队需要追踪从注册到试用到付费的完整销售流程。传统做法是：买一个 SaaS CRM、花几周配置、再安排人每天维护。
+COCO 团队需要追踪从注册到试用到付费的完整销售流程。传统做法是：买一个 SaaS CRM、花几周配置、再安排人每天维护。
 
 他们选了另一条路——让 AI Agent **Zylos** 直接设计并搭建整套系统。
 
@@ -827,7 +827,7 @@ CoCo 团队需要追踪从注册到试用到付费的完整销售流程。传统
 
 <div class="video-showcase">
   <div class="video-container">
-    <iframe src="https://www.youtube.com/embed/u7o-1GCO89E" title="CoCo CRM 自动化演示" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/u7o-1GCO89E" title="COCO CRM 自动化演示" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
 </div>
 
@@ -988,7 +988,7 @@ CoCo 团队需要追踪从注册到试用到付费的完整销售流程。传统
 
 ## 为什么这个案例重要
 
-CoCo 团队用 CoCo 做的，不是把原有工作加速一点点——而是让原本**根本不会存在**的运营流水线跑起来了，因为用传统方式搭需要几周时间和真金白银。
+COCO 团队用 COCO 做的，不是把原有工作加速一点点——而是让原本**根本不会存在**的运营流水线跑起来了，因为用传统方式搭需要几周时间和真金白银。
 
 这是一个简单的验证：**如果 AI 连自己公司的 CRM 都能从零搭建并持续运营，它也能为你做同样的事。**
 
@@ -997,7 +997,7 @@ CoCo 团队用 CoCo 做的，不是把原有工作加速一点点——而是让
 <div class="blog-meta">
   <div class="blog-meta-item">
     <span class="blog-meta-label">Written by</span>
-    <span class="blog-meta-value">CoCo Team</span>
+    <span class="blog-meta-value">COCO Team</span>
   </div>
   <div class="blog-meta-item">
     <span class="blog-meta-label">Published on</span>
@@ -1008,8 +1008,8 @@ CoCo 团队用 CoCo 做的，不是把原有工作加速一点点——而是让
 <div class="case-section">
   <div class="case-cta">
     <h2>让 AI 帮你搭建运营系统</h2>
-    <p>像 CoCo 一样，从一个需求描述开始</p>
-    <a href="https://coco.xyz" class="cta-btn">开始试用 CoCo</a>
+    <p>像 COCO 一样，从一个需求描述开始</p>
+    <a href="https://coco.xyz" class="cta-btn">开始试用 COCO</a>
   </div>
 </div>
 
@@ -1017,7 +1017,7 @@ CoCo 团队用 CoCo 做的，不是把原有工作加速一点点——而是让
   <div class="blog-divider-shell">🐚</div>
   <h3>更多案例</h3>
   <div class="blog-related-grid">
-    <a class="blog-related-card" href="/docs/zh/case-studies/social-media">
+    <a class="blog-related-card" href="/zh/case-studies/social-media">
       <div class="blog-related-card-img">📱</div>
       <div class="blog-related-card-body">
         <div class="blog-related-card-label">AI Agent 案例研究</div>

--- a/docs/zh/case-studies/social-media.md
+++ b/docs/zh/case-studies/social-media.md
@@ -825,7 +825,7 @@ head:
     <div class="card-label compliance">科技合规</div>
     <h3>某科技合规公司</h3>
     <div class="card-meta">BD 和市场负责人 · 一人扛全部</div>
-    <p>工作覆盖 KOL 监控、内容生产、会议 BD、线索管理——这个范围通常需要好几个专岗。她带着一个具体需求来找 CoCo。</p>
+    <p>工作覆盖 KOL 监控、内容生产、会议 BD、线索管理——这个范围通常需要好几个专岗。她带着一个具体需求来找 COCO。</p>
   </div>
   <div class="company-card">
     <div class="card-label media">科技媒体</div>
@@ -839,7 +839,7 @@ head:
 
 <div class="video-showcase">
   <div class="video-container">
-    <iframe src="https://www.youtube.com/embed/jFGNry0BohA" title="CoCo 社媒自动化演示" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe src="https://www.youtube.com/embed/jFGNry0BohA" title="COCO 社媒自动化演示" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
 </div>
 
@@ -855,7 +855,7 @@ head:
   <p>找一下某项目关注列表里有哪些 KOL 最近发了新闻，最近两小时的</p>
 </div>
 
-CoCo 扫描了 **325 个关注账号**，找出 **4 条近期 KOL 推文**，附带直链，结果里包括多个头部账号（百万级粉丝）——**几分钟内完成**，不需要人工刷 Twitter。
+COCO 扫描了 **325 个关注账号**，找出 **4 条近期 KOL 推文**，附带直链，结果里包括多个头部账号（百万级粉丝）——**几分钟内完成**，不需要人工刷 Twitter。
 
 这一个交互打开了一场更大的对话。
 
@@ -865,7 +865,7 @@ CoCo 扫描了 **325 个关注账号**，找出 **4 条近期 KOL 推文**，附
 
 ## 从 prompt 到 <em>完整运营模型</em>
 
-CoCo 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
+COCO 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
 
 <div class="workflow-section">
   <div class="workflow-block marketing">
@@ -926,7 +926,7 @@ CoCo 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
 
 ## 媒体团队的 <em>半自动化发布</em>
 
-新加坡的科技媒体小团队接入 CoCo 后：
+新加坡的科技媒体小团队接入 COCO 后：
 
 - AI 数字员工自动生成**符合各平台调性**的内容——Telegram 群、Twitter、Newsletter 各不相同
 - 定时发布到社群和社交媒体渠道
@@ -939,7 +939,7 @@ CoCo 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
   <div class="publish-flow">
     <div class="publish-source">
       <div class="publish-icon">🤖</div>
-      <div class="publish-label">CoCo AI</div>
+      <div class="publish-label">COCO AI</div>
       <div class="publish-sub">内容引擎</div>
     </div>
     <div class="publish-arrows">
@@ -1002,7 +1002,7 @@ CoCo 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
 
 <div class="insight-block">
   <h3>两个案例放在一起看</h3>
-  <p>无论你是合规公司里一个人扛起 BD 和市场的负责人，还是小媒体团队想覆盖整个行业，CoCo 的解法是一样的——<strong>AI 扛产量，人管策略</strong>。谁先发布、谁先触达对的人，谁就赢。</p>
+  <p>无论你是合规公司里一个人扛起 BD 和市场的负责人，还是小媒体团队想覆盖整个行业，COCO 的解法是一样的——<strong>AI 扛产量，人管策略</strong>。谁先发布、谁先触达对的人，谁就赢。</p>
 </div>
 
 </div>
@@ -1010,7 +1010,7 @@ CoCo 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
 <div class="blog-meta">
   <div class="blog-meta-item">
     <span class="blog-meta-label">Written by</span>
-    <span class="blog-meta-value">CoCo Team</span>
+    <span class="blog-meta-value">COCO Team</span>
   </div>
   <div class="blog-meta-item">
     <span class="blog-meta-label">Published on</span>
@@ -1022,7 +1022,7 @@ CoCo 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
   <div class="case-cta">
     <h2>让 AI 接管你的内容产量</h2>
     <p>从一条消息开始，构建完整运营模型</p>
-    <a href="https://coco.xyz" class="cta-btn">开始试用 CoCo</a>
+    <a href="https://coco.xyz" class="cta-btn">开始试用 COCO</a>
   </div>
 </div>
 
@@ -1030,11 +1030,11 @@ CoCo 和她一起设计了覆盖市场、BD、销售运营的全套工作流：
   <div class="blog-divider-shell">🐚</div>
   <h3>更多案例</h3>
   <div class="blog-related-grid">
-    <a class="blog-related-card" href="/docs/zh/case-studies/crm">
+    <a class="blog-related-card" href="/zh/case-studies/crm">
       <div class="blog-related-card-img">📊</div>
       <div class="blog-related-card-body">
         <div class="blog-related-card-label">AI Agent 案例研究</div>
-        <div class="blog-related-card-title">CoCo CRM — AI 搭建，AI 运营</div>
+        <div class="blog-related-card-title">COCO CRM — AI 搭建，AI 运营</div>
         <div class="blog-related-card-desc">一套由 AI Agent 从零设计、搭建并每天自动运营的 CRM 系统。</div>
       </div>
     </a>


### PR DESCRIPTION
## Summary
- Rename all CoCo → COCO across case study pages, sidebar config, and nav dropdown
- Fix blog-related card links that had `/docs/` prefix causing 404 on docs.coco.xyz

## Test plan
- [ ] Verify "更多案例" cards link correctly on docs.coco.xyz
- [ ] Confirm all text shows COCO (not CoCo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)