### PR TITLE
fix: add deployments write permission for CF Pages workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`cloudflare/pages-action@v1` failed with 403 when creating GitHub deployment:
> Resource not accessible by integration (deployments=write required)

## Fix

Add `permissions: deployments: write` to the job so the GITHUB_TOKEN can create deployment records.

## Impact

No code changes. Workflow-only fix — unblocks CF Pages deployment.