### PR TITLE
Add HxA AI Team case study (EN + ZH)

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -267,6 +267,7 @@ export default defineConfig({
               items: [
                 { text: 'Capability Showcase', link: '/case-studies/' },
                 { text: 'COCO CRM — Built by AI, Run by AI', link: '/case-studies/crm' },
+                { text: 'HxA AI Team — 7 Parallel Agents', link: '/case-studies/hxa-team' },
                 { text: 'Social Media & BD Automation', link: '/case-studies/social-media' },
                 { text: 'AI Due Diligence — 20 Hours to 2', link: '/case-studies/deal-flow-dd' },
                 { text: 'Customer Service Email Automation', link: '/case-studies/email-automation' },
@@ -410,6 +411,7 @@ export default defineConfig({
               items: [
                 { text: '能力展示', link: '/zh/case-studies/' },
                 { text: 'COCO CRM — AI 搭建，AI 运营', link: '/zh/case-studies/crm' },
+                { text: 'HxA AI 团队 — 7 个 Agent 并行协作', link: '/zh/case-studies/hxa-team' },
                 { text: '社媒与 BD 自动化', link: '/zh/case-studies/social-media' },
                 { text: 'AI 投资尽调 — 20小时压缩到2小时', link: '/zh/case-studies/deal-flow-dd' },
                 { text: '客服邮件自动化', link: '/zh/case-studies/email-automation' },

--- a/docs/.vitepress/theme/CocoHeader.vue
+++ b/docs/.vitepress/theme/CocoHeader.vue
@@ -23,6 +23,7 @@ const navItems = computed(() => {
           title: isZh ? '案例研究' : 'Case Studies',
           items: [
             { icon: '📊', text: isZh ? 'COCO CRM' : 'COCO CRM', desc: isZh ? 'AI 搭建，AI 运营' : 'Built by AI, Run by AI', link: isZh ? '/zh/case-studies/crm' : '/case-studies/crm' },
+            { icon: '🧠', text: isZh ? 'HxA AI 团队' : 'HxA AI Team', desc: isZh ? '7 个 Agent 并行协作' : '7 agents working in parallel', link: isZh ? '/zh/case-studies/hxa-team' : '/case-studies/hxa-team' },
             { icon: '📱', text: isZh ? '社媒自动化' : 'Social Media & BD', desc: isZh ? '两家公司，同一个突破' : 'Two Companies, One Breakthrough', link: isZh ? '/zh/case-studies/social-media' : '/case-studies/social-media' },
             { icon: '📋', text: isZh ? 'AI 投资尽调' : 'AI Due Diligence', desc: isZh ? '20小时压缩到2小时' : '20 hours down to 2', link: isZh ? '/zh/case-studies/deal-flow-dd' : '/case-studies/deal-flow-dd' },
             { icon: '📧', text: isZh ? '邮件自动化' : 'Email Automation', desc: isZh ? '真实用户邮件识别、提醒与草稿起草' : 'Detect, alert, and draft replies for real customer emails', link: isZh ? '/zh/case-studies/email-automation' : '/case-studies/email-automation' },

--- a/docs/case-studies/hxa-team.md
+++ b/docs/case-studies/hxa-team.md
@@ -1,0 +1,1177 @@
+---
+layout: page
+title: "HxA AI Team — 7 Parallel AI Agents for Enterprise Team Automation"
+description: "HxA built a 7-agent AI team with COCO: Coordinator, Frontend, Backend, DevOps, UI/UX, and Copywriter AI Agents working in parallel. A 3-4 person team delivers 10x output. Enterprise AI automation that goes from idea to a live website in 20 minutes."
+head:
+  - - meta
+    - property: og:title
+      content: "HxA AI Team — 7 Parallel AI Agents for Enterprise Team Automation"
+  - - meta
+    - property: og:description
+      content: "COCO AI Agent enterprise automation: 7 specialized AI Agents running in parallel as a digital employee team. 3-4 person team achieves 10x output, website live in 20 minutes."
+---
+
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&display=swap');
+
+/* ===== Ocean Palette =====
+   Primary:   #5CC5C5 (teal/turquoise — water)
+   Accent:    #FF7B7B (coral red — crabs/coral)
+   Secondary: #B388D9 (lavender — octopus)
+   Mint:      #A8D8B9 (soft green — seaweed)
+   Warm:      #F5E64D (yellow — from reef text)
+===== */
+
+/* ===== Case Study — Premium Landing ===== */
+.case-hero {
+  position: sticky;
+  top: 64px;
+  z-index: 5;
+  overflow: hidden;
+  padding: 100px 24px 72px;
+  text-align: center;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  border-radius: 0 0 32px 32px;
+  margin: -32px -24px 0;
+}
+.case-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(10, 40, 60, 0.55) 0%,
+    rgba(10, 40, 60, 0.35) 50%,
+    rgba(10, 40, 60, 0.15) 100%
+  );
+  pointer-events: none;
+}
+.case-hero::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: linear-gradient(to top, var(--vp-c-bg), transparent);
+  pointer-events: none;
+}
+.case-hero > * {
+  position: relative;
+  z-index: 1;
+}
+.case-hero .hero-text-box {
+  display: block;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0;
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+}
+.case-body {
+  position: relative;
+  z-index: 10;
+  background: var(--vp-c-bg);
+  padding-top: 48px;
+  margin: 0 -24px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+.case-hero h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 800;
+  line-height: 1.15;
+  color: #fff;
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 16px rgba(0, 0, 0, 0.6), 0 1px 4px rgba(0, 0, 0, 0.5), 0 0 40px rgba(0, 0, 0, 0.3);
+}
+.case-hero h1 em {
+  font-style: normal;
+  color: #A8E8E8;
+  -webkit-text-fill-color: #A8E8E8;
+  text-shadow: 0 2px 20px rgba(92, 197, 197, 0.4), 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+.case-hero .subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  color: #fff;
+  max-width: 640px;
+  margin: 0 auto 32px;
+  line-height: 1.6;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+.case-hero .hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+  flex-wrap: wrap;
+}
+.case-hero .stat {
+  text-align: center;
+}
+.case-hero .stat-value {
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #F5E64D;
+  line-height: 1.1;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+}
+.case-hero .stat-label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Section styling */
+.case-section {
+  max-width: 800px;
+  margin: 0 auto 64px;
+  padding: 0 24px;
+}
+.case-section h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  color: var(--vp-c-text-1);
+}
+.case-section h2 em {
+  font-style: normal;
+  color: #5CC5C5;
+}
+.case-section p {
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--vp-c-text-2);
+}
+
+/* Project overview card */
+.project-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin: 0 0 40px;
+  padding: 28px 24px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+}
+.po-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.po-icon {
+  font-size: 1.2rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+.po-content {
+  display: flex;
+  flex-direction: column;
+}
+.po-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vp-c-text-3);
+}
+.po-value {
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+}
+
+/* Pipeline cards — timeline style */
+.pipeline-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 32px 0;
+  position: relative;
+  padding-left: 40px;
+}
+.pipeline-grid::before {
+  content: '';
+  position: absolute;
+  left: 15px;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(to bottom, #5CC5C5, #B388D9, #FF7B7B);
+  border-radius: 2px;
+}
+.pipeline-card {
+  position: relative;
+  padding: 24px 28px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  transition: all 0.3s ease;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+.pipeline-card::before {
+  content: '';
+  position: absolute;
+  left: -33px;
+  top: 32px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #5CC5C5;
+  border: 3px solid var(--vp-c-bg);
+  box-shadow: 0 0 0 2px #5CC5C5;
+  z-index: 1;
+}
+.pipeline-card:nth-child(2)::before { background: #B388D9; box-shadow: 0 0 0 2px #B388D9; }
+.pipeline-card:nth-child(3)::before { background: #FF7B7B; box-shadow: 0 0 0 2px #FF7B7B; }
+.pipeline-card:hover {
+  border-color: #5CC5C5;
+  transform: translateX(4px);
+  box-shadow: 0 8px 32px rgba(92, 197, 197, 0.1);
+}
+.pipeline-card .time-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  font-family: 'Plus Jakarta Sans', monospace;
+  background: rgba(92, 197, 197, 0.1);
+  color: #4BA8A8;
+  margin-bottom: 10px;
+}
+.pipeline-card h3 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--vp-c-text-1);
+}
+.pipeline-card p {
+  font-size: 0.92rem;
+  line-height: 1.65;
+  color: var(--vp-c-text-2);
+  margin: 0;
+}
+.pipeline-card .card-icon {
+  position: absolute;
+  top: 24px;
+  right: 20px;
+  font-size: 2rem;
+  opacity: 0.12;
+}
+@media (max-width: 768px) {
+  .case-hero {
+    position: relative;
+    top: auto;
+    padding: 56px 20px 40px;
+    margin: -16px -16px 0;
+    border-radius: 0 0 20px 20px;
+  }
+  .case-hero h1 {
+    font-size: 1.6rem;
+    margin-bottom: 12px;
+    text-align: center;
+  }
+  .case-hero .subtitle {
+    font-size: 0.9rem;
+    margin-bottom: 20px;
+    line-height: 1.5;
+  }
+  .case-hero .subtitle br { display: none; }
+  .case-hero .hero-stats {
+    gap: 24px;
+  }
+  .case-hero .stat-value {
+    font-size: 1.8rem;
+  }
+  .case-hero .stat-label {
+    font-size: 11px;
+  }
+  .case-body {
+    margin: 0 -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
+  }
+  .case-section {
+    padding: 0 12px;
+    margin-bottom: 40px;
+    text-align: center;
+  }
+  .case-section h2 {
+    font-size: 1.4rem;
+    text-align: center;
+  }
+  .case-section p {
+    font-size: 0.95rem;
+    text-align: center;
+  }
+  .pipeline-grid {
+    text-align: left;
+  }
+  .arch-table {
+    text-align: left;
+  }
+  .pipeline-grid { padding-left: 32px; }
+  .pipeline-card::before { left: -25px; }
+  .pipeline-card {
+    padding: 18px 16px;
+  }
+  .pipeline-card h3 {
+    font-size: 1rem;
+  }
+  .pipeline-card .card-icon {
+    font-size: 1.5rem;
+    top: 18px;
+    right: 14px;
+  }
+  .case-cta {
+    padding: 40px 16px;
+    margin: 32px -16px 0;
+    border-radius: 16px;
+  }
+  .case-cta h2 {
+    font-size: 1.4rem;
+  }
+  .case-quote {
+    padding: 24px 20px 24px 36px;
+  }
+  .arch-table {
+    font-size: 0.85rem;
+  }
+  .arch-table th, .arch-table td {
+    padding: 10px 12px;
+  }
+  .blog-meta {
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+  }
+  .blog-related-grid {
+    grid-template-columns: 1fr;
+  }
+  .project-overview {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Results block */
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin: 32px 0;
+}
+@media (max-width: 768px) {
+  .results-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px;
+  }
+  .result-card {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    text-align: left;
+    padding: 24px;
+    gap: 16px;
+  }
+  .result-card::after {
+    width: 4px;
+    height: 100%;
+    top: 0;
+    left: 0;
+    right: auto;
+    bottom: 0;
+    border-radius: 20px 0 0 20px;
+  }
+  .result-card .result-number {
+    font-size: 2rem;
+    min-width: 80px;
+    flex-shrink: 0;
+  }
+  .result-card .result-desc {
+    margin-top: 0;
+  }
+}
+.result-card {
+  text-align: center;
+  padding: 36px 24px;
+  border-radius: 20px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  box-shadow: 0 4px 24px rgba(92, 197, 197, 0.06);
+  position: relative;
+  overflow: hidden;
+}
+.result-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #7DD4D4, #A8D8B9);
+  border-radius: 20px 20px 0 0;
+}
+.result-card:nth-child(2)::after {
+  background: linear-gradient(90deg, #B388D9, #D4A8E8);
+}
+.result-card:nth-child(3)::after {
+  background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
+}
+.result-card .result-number {
+  font-size: 2.6rem;
+  font-weight: 800;
+  color: #3BA8A8;
+  line-height: 1.1;
+  font-family: 'Playfair Display', Georgia, serif;
+}
+.result-card:nth-child(2) .result-number { color: #9B6CC4; }
+.result-card:nth-child(3) .result-number { color: #E86060; }
+.result-card .result-desc {
+  font-size: 0.92rem;
+  color: var(--vp-c-text-2);
+  margin-top: 12px;
+  line-height: 1.5;
+}
+
+/* Quote block */
+.case-quote {
+  position: relative;
+  padding: 32px 32px 32px 48px;
+  margin: 40px 0;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(92, 197, 197, 0.06), rgba(179, 136, 217, 0.04));
+  border-left: 4px solid #5CC5C5;
+}
+.case-quote::before {
+  content: '\201C';
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  font-size: 3rem;
+  color: #5CC5C5;
+  opacity: 0.4;
+  line-height: 1;
+  font-family: Georgia, serif;
+}
+.case-quote p {
+  font-size: 1.1rem;
+  font-style: italic;
+  line-height: 1.7;
+  color: var(--vp-c-text-1);
+  margin: 0;
+}
+
+/* Architecture table */
+.arch-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 24px 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+}
+.arch-table th {
+  background: rgba(92, 197, 197, 0.1);
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 14px 16px;
+  text-align: left;
+}
+.arch-table td {
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  color: var(--vp-c-text-2);
+  border-top: 1px solid var(--vp-c-divider);
+}
+.arch-table tr:hover td {
+  background: var(--vp-c-bg-soft);
+}
+
+/* Architecture visualization */
+.arch-visual {
+  margin: 32px 0;
+  padding: 32px 24px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  text-align: center;
+  color: #fff;
+}
+.arch-visual-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 24px;
+}
+.arch-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+.arch-node {
+  padding: 16px 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  min-width: 100px;
+}
+.arch-node.input { background: rgba(179, 136, 217, 0.2); }
+.arch-node.core { background: rgba(92, 197, 197, 0.2); border-color: rgba(92, 197, 197, 0.4); }
+.arch-node.output { background: rgba(168, 216, 185, 0.2); }
+.arch-node-icon { font-size: 1.6rem; margin-bottom: 6px; }
+.arch-node-label { font-size: 0.85rem; font-weight: 600; }
+.arch-arrow {
+  width: 32px;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(92, 197, 197, 0.3), #5CC5C5);
+  position: relative;
+}
+.arch-arrow::after {
+  content: '';
+  position: absolute;
+  right: -4px;
+  top: -4px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid #5CC5C5;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+}
+.arch-sheets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.arch-sheet {
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  background: rgba(92, 197, 197, 0.12);
+  color: #7DD4D4;
+  border: 1px solid rgba(92, 197, 197, 0.2);
+}
+.arch-outputs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.arch-out {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+@media (max-width: 640px) {
+  .arch-flow { flex-direction: column; }
+  .arch-arrow { width: 2px; height: 20px; background: linear-gradient(to bottom, rgba(92, 197, 197, 0.3), #5CC5C5); }
+  .arch-arrow::after { right: auto; top: auto; bottom: -4px; left: -4px; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 8px solid #5CC5C5; border-bottom: none; }
+}
+
+/* CTA block */
+.case-cta {
+  text-align: center;
+  padding: 64px 24px;
+  margin: 48px -24px 0;
+  background: url('/otter-banner.png') center/cover no-repeat;
+  border-radius: 24px;
+  position: relative;
+  overflow: hidden;
+}
+.case-cta::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 30, 40, 0.45);
+}
+.case-cta > * {
+  position: relative;
+  z-index: 1;
+}
+.case-cta h2 {
+  color: #fff;
+  font-size: 1.8rem;
+  margin-bottom: 12px;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+.case-cta p {
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 28px;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.case-cta .cta-btn {
+  display: inline-block;
+  padding: 14px 36px;
+  border-radius: 999px;
+  background: #5CC5C5;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.case-cta .cta-btn:hover {
+  background: #4BA8A8;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.3);
+}
+
+/* ===== Scroll Animations ===== */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(32px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(32px);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.animate-on-scroll.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.pipeline-card {
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: opacity 0.6s ease, transform 0.6s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.pipeline-card.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+.pipeline-card:nth-child(2) { transition-delay: 0.15s; }
+.pipeline-card:nth-child(3) { transition-delay: 0.3s; }
+.result-card {
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+.result-card.visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.result-card:nth-child(2) { transition-delay: 0.12s; }
+.result-card:nth-child(3) { transition-delay: 0.24s; }
+
+/* ===== Premium Handwritten Font ===== */
+.case-hero h1,
+.case-section h2 {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+}
+.case-hero h1 em,
+.case-section h2 em {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+  font-style: italic;
+}
+
+/* Dark mode fine-tuning */
+.dark .pipeline-card {
+  background: rgba(255, 255, 255, 0.03);
+}
+.dark .result-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* ===== Blog meta + Related posts ===== */
+.blog-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 0.88rem;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.blog-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-value {
+  color: var(--vp-c-text-2);
+  font-weight: 500;
+}
+
+.blog-related {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  position: relative;
+}
+.blog-divider-shell {
+  position: absolute;
+  top: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 1.6rem;
+  background: var(--vp-c-bg);
+  padding: 0 12px;
+  line-height: 1;
+}
+.blog-related h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  margin: 0 0 24px;
+  text-align: center;
+}
+.blog-related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+.blog-related-card {
+  display: block;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  text-decoration: none;
+  transition: all 0.2s;
+  background: var(--vp-c-bg);
+}
+.blog-related-card:hover {
+  border-color: #5CC5C5;
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.1);
+}
+.blog-related-card-img {
+  height: 160px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 2.5rem;
+  position: relative;
+  overflow: hidden;
+}
+.blog-related-card-img::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  opacity: 0.3;
+}
+.blog-related-card-body {
+  padding: 16px 20px;
+}
+.blog-related-card-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5CC5C5;
+  margin-bottom: 6px;
+}
+.blog-related-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+  margin: 0;
+}
+.blog-related-card-desc {
+  font-size: 0.85rem;
+  color: var(--vp-c-text-3);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+.dark .blog-related-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+</style>
+
+<div class="case-hero">
+  <div class="hero-text-box">
+    <h1>From 1 AI Employee<br/><em>to a Full AI Team</em></h1>
+    <p class="subtitle">7 agents, each with a role, running in parallel.<br/>Kevin sets direction. The team executes.</p>
+    <div class="hero-stats">
+      <div class="stat">
+        <div class="stat-value">7</div>
+        <div class="stat-label">Parallel Agents</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">20 min</div>
+        <div class="stat-label">Idea to Live Site</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">10x</div>
+        <div class="stat-label">Output from 3-4 People</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="case-body">
+<div class="case-section">
+
+<div class="project-overview">
+  <div class="po-field">
+    <span class="po-icon">🏢</span>
+    <div class="po-content">
+      <span class="po-label">Company</span>
+      <span class="po-value">HxA (Singapore technology company)</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">👥</span>
+    <div class="po-content">
+      <span class="po-label">Operating Model</span>
+      <span class="po-value">1 lead + 7 parallel AI agents</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">⚡</span>
+    <div class="po-content">
+      <span class="po-label">Launch Speed</span>
+      <span class="po-value">20 minutes from idea to live page</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🔧</span>
+    <div class="po-content">
+      <span class="po-label">Core Stack</span>
+      <span class="po-value">COCO + HXA Connect</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">📊</span>
+    <div class="po-content">
+      <span class="po-label">Core Roles</span>
+      <span class="po-value">Coordination, frontend, backend, DevOps, UI/UX, copy</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">📈</span>
+    <div class="po-content">
+      <span class="po-label">Outcome</span>
+      <span class="po-value">10x output with a much smaller team</span>
+    </div>
+  </div>
+</div>
+
+## Context: <em>Not More Tools, a Real Team</em>
+
+Most companies approach AI as a point solution: a better writing tool, a faster coding assistant, a smarter support bot. HxA approached it as an organizational design question. If a team of 3-4 people needs to deliver with the throughput of a much larger company, what kind of operating structure actually makes that possible?
+
+The answer was not "more prompts." It was a coordinated team of AI agents with clear role boundaries, shared context, proactive reporting, and direct task handoff. Kevin issues direction once. Jessie coordinates. Specialist agents execute in parallel across frontend, backend, design, deployment, and content.
+
+That shift is what makes this an enterprise AI automation case study rather than a demo. The bottleneck stops being whether AI can do work at all, and becomes whether the human lead can direct a digital team at scale.
+
+</div>
+
+<div class="case-section">
+
+## Three Operating Lines <em>Running in Parallel</em>
+
+HxA's setup is not seven agents talking over each other. It is a repeatable operating model with three core lines: task decomposition, parallel execution, and proactive reporting. Those lines remove the waiting, chasing, and context loss that usually slow small teams down.
+
+The effect is not cosmetic. It changes the calendar time of delivery because work that would normally wait for handoffs can start immediately.
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">🧠</div>
+    <div class="time-badge">Immediately on intake</div>
+    <h3>Task Decomposition</h3>
+    <p>Jessie receives the goal, identifies which workstreams can run in parallel, and assigns scope before execution begins.</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">⚙️</div>
+    <div class="time-badge">Continuously during work</div>
+    <h3>Parallel Execution</h3>
+    <p>Frontend, backend, design, copy, and deployment move at the same time instead of waiting through serial handoffs.</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">📣</div>
+    <div class="time-badge">At every key checkpoint</div>
+    <h3>Proactive Reporting</h3>
+    <p>Agents report what is done, what is blocked, and what is next, so Kevin manages direction instead of chasing status.</p>
+  </div>
+</div>
+
+The result is not "faster people." It is a better operating system for execution.
+
+</div>
+
+<div class="case-section">
+
+## Team Architecture
+
+HxA's seven AI agents are not interchangeable. Each role owns a specific class of work, which reduces duplicated effort and keeps context boundaries clean.
+
+The real leverage comes from explicit ownership and visible coordination, not from the raw number of agents.
+
+<table class="arch-table">
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>Primary Responsibility</th>
+      <th>How It Collaborates</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Jessie / Lead Agent</strong></td>
+      <td>Routing, prioritization, shared context</td>
+      <td>Coordinates the rest of the team</td>
+    </tr>
+    <tr>
+      <td><strong>Frontend Agent</strong></td>
+      <td>Page structure, interactions, implementation</td>
+      <td>Works in parallel with design and backend</td>
+    </tr>
+    <tr>
+      <td><strong>Backend Agent</strong></td>
+      <td>APIs, data logic, service behavior</td>
+      <td>Keeps contracts aligned with frontend</td>
+    </tr>
+    <tr>
+      <td><strong>DevOps Agent</strong></td>
+      <td>Environment, deployment, release path</td>
+      <td>Pushes work into production</td>
+    </tr>
+    <tr>
+      <td><strong>UI/UX Agent</strong></td>
+      <td>Visual system, component quality, UX consistency</td>
+      <td>Closes quality with frontend</td>
+    </tr>
+    <tr>
+      <td><strong>Copy Agent</strong></td>
+      <td>Messaging, page copy, brand voice</td>
+      <td>Supplies production-ready content</td>
+    </tr>
+    <tr>
+      <td><strong>Coordinator</strong></td>
+      <td>Cross-channel sync and status bridging</td>
+      <td>Keeps information from being lost</td>
+    </tr>
+  </tbody>
+</table>
+
+</div>
+
+<div class="case-section">
+
+<div class="arch-visual">
+  <div class="arch-visual-title">HxA Multi-Agent Delivery Flow</div>
+  <div class="arch-flow">
+    <div class="arch-node input">
+      <div class="arch-node-icon">🧭</div>
+      <div class="arch-node-label">Kevin sets direction</div>
+    </div>
+    <div class="arch-arrow"></div>
+    <div class="arch-node core">
+      <div class="arch-node-icon">🐙</div>
+      <div class="arch-node-label">Jessie orchestrates</div>
+    </div>
+    <div class="arch-arrow"></div>
+    <div class="arch-node output">
+      <div class="arch-node-icon">⚡</div>
+      <div class="arch-node-label">Specialists ship in parallel</div>
+    </div>
+  </div>
+  <div class="arch-sheets">
+    <span class="arch-sheet">Frontend</span>
+    <span class="arch-sheet">Backend</span>
+    <span class="arch-sheet">DevOps</span>
+    <span class="arch-sheet">UI/UX</span>
+    <span class="arch-sheet">Copy</span>
+    <span class="arch-sheet">Coordination</span>
+    <span class="arch-sheet">Shared memory</span>
+  </div>
+  <div class="arch-outputs">
+    <span class="arch-out">📋 Proactive status updates</span>
+    <span class="arch-out">🌐 Live site in 20 minutes</span>
+    <span class="arch-out">🧠 Shared context across sessions</span>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## Results
+
+The value here is not merely that AI can write, design, or deploy. The value is that the team can coordinate those capabilities at the same time, with enough structure that the human lead only intervenes on judgment and prioritization.
+
+That is what turns AI from an assistant into an execution layer.
+
+<div class="results-grid">
+  <div class="result-card">
+    <div class="result-number">7</div>
+    <div class="result-desc">Parallel agents<br/><small>A team model, not a single-thread tool</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">20 min</div>
+    <div class="result-desc">Idea to launch<br/><small>Real delivery, not a concept demo</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">10x</div>
+    <div class="result-desc">Output leverage<br/><small>Small team, much larger throughput</small></div>
+  </div>
+</div>
+
+The real shift is from one person using AI to one person managing an AI team.
+
+</div>
+
+<div class="case-section">
+
+<div class="case-quote">
+  <p>The bottleneck isn't AI capability. It's my own capacity to direct the team. The bottleneck is me. — Kevin He, Founder, COCO.xyz</p>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## Why This Case Matters
+
+This case is useful because it shows a concrete operating model for small teams that need more execution capacity without adding a large headcount. Once the team structure is in place, every new project starts faster because the coordination layer already exists.
+
+For enterprises, the scarce resource is often not tools but reliable execution. HxA shows how AI becomes infrastructure when role boundaries, reporting discipline, and coordination rules are designed intentionally.
+
+That is why the lessons here are managerial as much as technical: clear ownership, proactive reporting, cross-checking, and shared memory are team principles first and AI principles second.
+
+</div>
+
+<div class="case-section">
+
+## Frequently Asked Questions
+
+### Q: How long does it take to configure a team like HxA's?
+
+If workflows and role boundaries are already clear, an initial setup can come together within days. The slower part is not model access. It is defining ownership, reporting rules, and coordination logic clearly enough for the system to run cleanly.
+
+### Q: What problem does HXA Connect solve?
+
+It solves the coordination gap between agents. Traditional chat platforms force too much work through a human relay. A real multi-agent team needs direct task, result, and status exchange between agents.
+
+### Q: How do you avoid chaos when multiple agents run at once?
+
+The answer is ownership. Each module has a single owner, key outputs can be cross-checked by a second agent, and the human lead only steps in on decisions that actually require judgment.
+
+### Q: What kind of teams benefit most from this model?
+
+Teams with multiple workstreams and limited headcount: product teams, operations teams, content teams, business development teams, and any environment where several modules can move in parallel.
+
+### Q: How is this different from using a normal AI assistant?
+
+A normal assistant is reactive and single-threaded. A system like HxA is a continuously running digital team with role specialization, shared memory, proactive reporting, and parallel execution.
+
+### Q: How do I get started with a multi-agent AI team?
+
+Visit coco.xyz to start a free trial. Describe your team structure and workflows to the AI Agent, and it will help you configure roles, coordination rules, and reporting flows. No programming background required.
+
+</div>
+
+<div class="blog-meta">
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Written by</span>
+    <span class="blog-meta-value">COCO Team</span>
+  </div>
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Published on</span>
+    <span class="blog-meta-value">April 2026</span>
+  </div>
+</div>
+
+<div class="case-section">
+  <div class="case-cta">
+    <h2>Start with one AI employee, then scale into a team.</h2>
+    <p>You set the direction. A manageable AI team handles execution.</p>
+    <a href="https://coco.xyz" class="cta-btn">Try COCO Free</a>
+  </div>
+</div>
+
+<div class="blog-related">
+  <div class="blog-divider-shell">🐚</div>
+  <h3>More Case Studies</h3>
+  <div class="blog-related-grid">
+    <a class="blog-related-card" href="/case-studies/crm">
+      <div class="blog-related-card-img">📊</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent Case Study</div>
+        <div class="blog-related-card-title">COCO CRM — Built by AI, Run by AI</div>
+        <div class="blog-related-card-desc">A complete CRM system designed, built, and operated daily by an AI agent.</div>
+      </div>
+    </a>
+    <a class="blog-related-card" href="/case-studies/social-media">
+      <div class="blog-related-card-img">📱</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent Case Study</div>
+        <div class="blog-related-card-title">Social Media & BD Automation</div>
+        <div class="blog-related-card-desc">From content publishing to outbound execution, one AI agent can run the workflow.</div>
+      </div>
+    </a>
+    <a class="blog-related-card" href="/case-studies/email-automation">
+      <div class="blog-related-card-img">📧</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent Case Study</div>
+        <div class="blog-related-card-title">Customer Service Email Automation</div>
+        <div class="blog-related-card-desc">AI monitors every inbound email, filters noise, drafts replies, and keeps humans in control of every send.</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+</div>
+
+<script setup>
+import { onMounted } from 'vue'
+onMounted(() => {
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        e.target.classList.add('visible')
+      }
+    })
+  }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' })
+  document.querySelectorAll('.case-section, .pipeline-card, .result-card, .arch-visual, .case-quote, .case-cta').forEach(el => {
+    el.classList.add('animate-on-scroll')
+    observer.observe(el)
+  })
+  // Pipeline cards get their own animation class
+  document.querySelectorAll('.pipeline-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+  document.querySelectorAll('.result-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+})
+</script>

--- a/docs/zh/case-studies/hxa-team.md
+++ b/docs/zh/case-studies/hxa-team.md
@@ -1,0 +1,1177 @@
+---
+layout: page
+title: "HxA AI 团队案例研究：7 个并行 Agent 如何实现企业AI自动化与 10 倍交付效率"
+description: "HxA 用 COCO 搭建 7 个并行 AI Agent，覆盖协调、前端、后端、DevOps、UI/UX 与文案，让 3-4 人团队获得 10 倍交付杠杆，20 分钟从想法到上线。"
+head:
+  - - meta
+    - property: og:title
+      content: "HxA AI 团队案例研究：7 个并行 Agent 如何实现企业AI自动化与 10 倍交付效率"
+  - - meta
+    - property: og:description
+      content: "HxA 用 COCO 搭建可管理的多 Agent AI 团队，把企业AI自动化从单点提效升级为团队级协作执行。"
+---
+
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&display=swap');
+
+/* ===== Ocean Palette =====
+   Primary:   #5CC5C5 (teal/turquoise — water)
+   Accent:    #FF7B7B (coral red — crabs/coral)
+   Secondary: #B388D9 (lavender — octopus)
+   Mint:      #A8D8B9 (soft green — seaweed)
+   Warm:      #F5E64D (yellow — from reef text)
+===== */
+
+/* ===== Case Study — Premium Landing ===== */
+.case-hero {
+  position: sticky;
+  top: 64px;
+  z-index: 5;
+  overflow: hidden;
+  padding: 100px 24px 72px;
+  text-align: center;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  border-radius: 0 0 32px 32px;
+  margin: -32px -24px 0;
+}
+.case-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(10, 40, 60, 0.55) 0%,
+    rgba(10, 40, 60, 0.35) 50%,
+    rgba(10, 40, 60, 0.15) 100%
+  );
+  pointer-events: none;
+}
+.case-hero::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: linear-gradient(to top, var(--vp-c-bg), transparent);
+  pointer-events: none;
+}
+.case-hero > * {
+  position: relative;
+  z-index: 1;
+}
+.case-hero .hero-text-box {
+  display: block;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0;
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+}
+.case-body {
+  position: relative;
+  z-index: 10;
+  background: var(--vp-c-bg);
+  padding-top: 48px;
+  margin: 0 -24px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+.case-hero h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 800;
+  line-height: 1.15;
+  color: #fff;
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 16px rgba(0, 0, 0, 0.6), 0 1px 4px rgba(0, 0, 0, 0.5), 0 0 40px rgba(0, 0, 0, 0.3);
+}
+.case-hero h1 em {
+  font-style: normal;
+  color: #A8E8E8;
+  -webkit-text-fill-color: #A8E8E8;
+  text-shadow: 0 2px 20px rgba(92, 197, 197, 0.4), 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+.case-hero .subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  color: #fff;
+  max-width: 640px;
+  margin: 0 auto 32px;
+  line-height: 1.6;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+.case-hero .hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+  flex-wrap: wrap;
+}
+.case-hero .stat {
+  text-align: center;
+}
+.case-hero .stat-value {
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #F5E64D;
+  line-height: 1.1;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+}
+.case-hero .stat-label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Section styling */
+.case-section {
+  max-width: 800px;
+  margin: 0 auto 64px;
+  padding: 0 24px;
+}
+.case-section h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  color: var(--vp-c-text-1);
+}
+.case-section h2 em {
+  font-style: normal;
+  color: #5CC5C5;
+}
+.case-section p {
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--vp-c-text-2);
+}
+
+/* Project overview card */
+.project-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin: 0 0 40px;
+  padding: 28px 24px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+}
+.po-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+.po-icon {
+  font-size: 1.2rem;
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+.po-content {
+  display: flex;
+  flex-direction: column;
+}
+.po-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vp-c-text-3);
+}
+.po-value {
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+}
+
+/* Pipeline cards — timeline style */
+.pipeline-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 32px 0;
+  position: relative;
+  padding-left: 40px;
+}
+.pipeline-grid::before {
+  content: '';
+  position: absolute;
+  left: 15px;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(to bottom, #5CC5C5, #B388D9, #FF7B7B);
+  border-radius: 2px;
+}
+.pipeline-card {
+  position: relative;
+  padding: 24px 28px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  transition: all 0.3s ease;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+.pipeline-card::before {
+  content: '';
+  position: absolute;
+  left: -33px;
+  top: 32px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #5CC5C5;
+  border: 3px solid var(--vp-c-bg);
+  box-shadow: 0 0 0 2px #5CC5C5;
+  z-index: 1;
+}
+.pipeline-card:nth-child(2)::before { background: #B388D9; box-shadow: 0 0 0 2px #B388D9; }
+.pipeline-card:nth-child(3)::before { background: #FF7B7B; box-shadow: 0 0 0 2px #FF7B7B; }
+.pipeline-card:hover {
+  border-color: #5CC5C5;
+  transform: translateX(4px);
+  box-shadow: 0 8px 32px rgba(92, 197, 197, 0.1);
+}
+.pipeline-card .time-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  font-family: 'Plus Jakarta Sans', monospace;
+  background: rgba(92, 197, 197, 0.1);
+  color: #4BA8A8;
+  margin-bottom: 10px;
+}
+.pipeline-card h3 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--vp-c-text-1);
+}
+.pipeline-card p {
+  font-size: 0.92rem;
+  line-height: 1.65;
+  color: var(--vp-c-text-2);
+  margin: 0;
+}
+.pipeline-card .card-icon {
+  position: absolute;
+  top: 24px;
+  right: 20px;
+  font-size: 2rem;
+  opacity: 0.12;
+}
+@media (max-width: 768px) {
+  .case-hero {
+    position: relative;
+    top: auto;
+    padding: 56px 20px 40px;
+    margin: -16px -16px 0;
+    border-radius: 0 0 20px 20px;
+  }
+  .case-hero h1 {
+    font-size: 1.6rem;
+    margin-bottom: 12px;
+    text-align: center;
+  }
+  .case-hero .subtitle {
+    font-size: 0.9rem;
+    margin-bottom: 20px;
+    line-height: 1.5;
+  }
+  .case-hero .subtitle br { display: none; }
+  .case-hero .hero-stats {
+    gap: 24px;
+  }
+  .case-hero .stat-value {
+    font-size: 1.8rem;
+  }
+  .case-hero .stat-label {
+    font-size: 11px;
+  }
+  .case-body {
+    margin: 0 -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
+  }
+  .case-section {
+    padding: 0 12px;
+    margin-bottom: 40px;
+    text-align: center;
+  }
+  .case-section h2 {
+    font-size: 1.4rem;
+    text-align: center;
+  }
+  .case-section p {
+    font-size: 0.95rem;
+    text-align: center;
+  }
+  .pipeline-grid {
+    text-align: left;
+  }
+  .arch-table {
+    text-align: left;
+  }
+  .pipeline-grid { padding-left: 32px; }
+  .pipeline-card::before { left: -25px; }
+  .pipeline-card {
+    padding: 18px 16px;
+  }
+  .pipeline-card h3 {
+    font-size: 1rem;
+  }
+  .pipeline-card .card-icon {
+    font-size: 1.5rem;
+    top: 18px;
+    right: 14px;
+  }
+  .case-cta {
+    padding: 40px 16px;
+    margin: 32px -16px 0;
+    border-radius: 16px;
+  }
+  .case-cta h2 {
+    font-size: 1.4rem;
+  }
+  .case-quote {
+    padding: 24px 20px 24px 36px;
+  }
+  .arch-table {
+    font-size: 0.85rem;
+  }
+  .arch-table th, .arch-table td {
+    padding: 10px 12px;
+  }
+  .blog-meta {
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+  }
+  .blog-related-grid {
+    grid-template-columns: 1fr;
+  }
+  .project-overview {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Results block */
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin: 32px 0;
+}
+@media (max-width: 768px) {
+  .results-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px;
+  }
+  .result-card {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    text-align: left;
+    padding: 24px;
+    gap: 16px;
+  }
+  .result-card::after {
+    width: 4px;
+    height: 100%;
+    top: 0;
+    left: 0;
+    right: auto;
+    bottom: 0;
+    border-radius: 20px 0 0 20px;
+  }
+  .result-card .result-number {
+    font-size: 2rem;
+    min-width: 80px;
+    flex-shrink: 0;
+  }
+  .result-card .result-desc {
+    margin-top: 0;
+  }
+}
+.result-card {
+  text-align: center;
+  padding: 36px 24px;
+  border-radius: 20px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  box-shadow: 0 4px 24px rgba(92, 197, 197, 0.06);
+  position: relative;
+  overflow: hidden;
+}
+.result-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #7DD4D4, #A8D8B9);
+  border-radius: 20px 20px 0 0;
+}
+.result-card:nth-child(2)::after {
+  background: linear-gradient(90deg, #B388D9, #D4A8E8);
+}
+.result-card:nth-child(3)::after {
+  background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
+}
+.result-card .result-number {
+  font-size: 2.6rem;
+  font-weight: 800;
+  color: #3BA8A8;
+  line-height: 1.1;
+  font-family: 'Playfair Display', Georgia, serif;
+}
+.result-card:nth-child(2) .result-number { color: #9B6CC4; }
+.result-card:nth-child(3) .result-number { color: #E86060; }
+.result-card .result-desc {
+  font-size: 0.92rem;
+  color: var(--vp-c-text-2);
+  margin-top: 12px;
+  line-height: 1.5;
+}
+
+/* Quote block */
+.case-quote {
+  position: relative;
+  padding: 32px 32px 32px 48px;
+  margin: 40px 0;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(92, 197, 197, 0.06), rgba(179, 136, 217, 0.04));
+  border-left: 4px solid #5CC5C5;
+}
+.case-quote::before {
+  content: '\201C';
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  font-size: 3rem;
+  color: #5CC5C5;
+  opacity: 0.4;
+  line-height: 1;
+  font-family: Georgia, serif;
+}
+.case-quote p {
+  font-size: 1.1rem;
+  font-style: italic;
+  line-height: 1.7;
+  color: var(--vp-c-text-1);
+  margin: 0;
+}
+
+/* Architecture table */
+.arch-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 24px 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+}
+.arch-table th {
+  background: rgba(92, 197, 197, 0.1);
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 14px 16px;
+  text-align: left;
+}
+.arch-table td {
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  color: var(--vp-c-text-2);
+  border-top: 1px solid var(--vp-c-divider);
+}
+.arch-table tr:hover td {
+  background: var(--vp-c-bg-soft);
+}
+
+/* Architecture visualization */
+.arch-visual {
+  margin: 32px 0;
+  padding: 32px 24px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  text-align: center;
+  color: #fff;
+}
+.arch-visual-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 24px;
+}
+.arch-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+.arch-node {
+  padding: 16px 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  min-width: 100px;
+}
+.arch-node.input { background: rgba(179, 136, 217, 0.2); }
+.arch-node.core { background: rgba(92, 197, 197, 0.2); border-color: rgba(92, 197, 197, 0.4); }
+.arch-node.output { background: rgba(168, 216, 185, 0.2); }
+.arch-node-icon { font-size: 1.6rem; margin-bottom: 6px; }
+.arch-node-label { font-size: 0.85rem; font-weight: 600; }
+.arch-arrow {
+  width: 32px;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(92, 197, 197, 0.3), #5CC5C5);
+  position: relative;
+}
+.arch-arrow::after {
+  content: '';
+  position: absolute;
+  right: -4px;
+  top: -4px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid #5CC5C5;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+}
+.arch-sheets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.arch-sheet {
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  background: rgba(92, 197, 197, 0.12);
+  color: #7DD4D4;
+  border: 1px solid rgba(92, 197, 197, 0.2);
+}
+.arch-outputs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.arch-out {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+@media (max-width: 640px) {
+  .arch-flow { flex-direction: column; }
+  .arch-arrow { width: 2px; height: 20px; background: linear-gradient(to bottom, rgba(92, 197, 197, 0.3), #5CC5C5); }
+  .arch-arrow::after { right: auto; top: auto; bottom: -4px; left: -4px; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 8px solid #5CC5C5; border-bottom: none; }
+}
+
+/* CTA block */
+.case-cta {
+  text-align: center;
+  padding: 64px 24px;
+  margin: 48px -24px 0;
+  background: url('/otter-banner.png') center/cover no-repeat;
+  border-radius: 24px;
+  position: relative;
+  overflow: hidden;
+}
+.case-cta::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 30, 40, 0.45);
+}
+.case-cta > * {
+  position: relative;
+  z-index: 1;
+}
+.case-cta h2 {
+  color: #fff;
+  font-size: 1.8rem;
+  margin-bottom: 12px;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+.case-cta p {
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 28px;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.case-cta .cta-btn {
+  display: inline-block;
+  padding: 14px 36px;
+  border-radius: 999px;
+  background: #5CC5C5;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.case-cta .cta-btn:hover {
+  background: #4BA8A8;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.3);
+}
+
+/* ===== Scroll Animations ===== */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(32px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(32px);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.animate-on-scroll.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.pipeline-card {
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: opacity 0.6s ease, transform 0.6s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.pipeline-card.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+.pipeline-card:nth-child(2) { transition-delay: 0.15s; }
+.pipeline-card:nth-child(3) { transition-delay: 0.3s; }
+.result-card {
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+.result-card.visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.result-card:nth-child(2) { transition-delay: 0.12s; }
+.result-card:nth-child(3) { transition-delay: 0.24s; }
+
+/* ===== Premium Handwritten Font ===== */
+.case-hero h1,
+.case-section h2 {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+}
+.case-hero h1 em,
+.case-section h2 em {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+  font-style: italic;
+}
+
+/* Dark mode fine-tuning */
+.dark .pipeline-card {
+  background: rgba(255, 255, 255, 0.03);
+}
+.dark .result-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* ===== Blog meta + Related posts ===== */
+.blog-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 0.88rem;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.blog-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-value {
+  color: var(--vp-c-text-2);
+  font-weight: 500;
+}
+
+.blog-related {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  position: relative;
+}
+.blog-divider-shell {
+  position: absolute;
+  top: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 1.6rem;
+  background: var(--vp-c-bg);
+  padding: 0 12px;
+  line-height: 1;
+}
+.blog-related h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  margin: 0 0 24px;
+  text-align: center;
+}
+.blog-related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+.blog-related-card {
+  display: block;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  text-decoration: none;
+  transition: all 0.2s;
+  background: var(--vp-c-bg);
+}
+.blog-related-card:hover {
+  border-color: #5CC5C5;
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.1);
+}
+.blog-related-card-img {
+  height: 160px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 2.5rem;
+  position: relative;
+  overflow: hidden;
+}
+.blog-related-card-img::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  opacity: 0.3;
+}
+.blog-related-card-body {
+  padding: 16px 20px;
+}
+.blog-related-card-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5CC5C5;
+  margin-bottom: 6px;
+}
+.blog-related-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+  margin: 0;
+}
+.blog-related-card-desc {
+  font-size: 0.85rem;
+  color: var(--vp-c-text-3);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+.dark .blog-related-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+</style>
+
+<div class="case-hero">
+  <div class="hero-text-box">
+    <h1>从 1 个 AI 员工到<br/><em>1 支 AI 团队</em></h1>
+    <p class="subtitle">7 个 Agent 各司其职、同时并行。<br/>Kevin 负责方向，AI 团队负责拆解、执行、汇报与上线。</p>
+    <div class="hero-stats">
+      <div class="stat">
+        <div class="stat-value">7</div>
+        <div class="stat-label">Agent 并行</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">20 分钟</div>
+        <div class="stat-label">从想法到上线</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">10x</div>
+        <div class="stat-label">3-4 人团队产出</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="case-body">
+<div class="case-section">
+
+<div class="project-overview">
+  <div class="po-field">
+    <span class="po-icon">🏢</span>
+    <div class="po-content">
+      <span class="po-label">客户</span>
+      <span class="po-value">HxA（新加坡科技公司）</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">👥</span>
+    <div class="po-content">
+      <span class="po-label">组织形态</span>
+      <span class="po-value">1 个负责人 + 7 个并行 Agent</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">⚡</span>
+    <div class="po-content">
+      <span class="po-label">交付速度</span>
+      <span class="po-value">20 分钟从零到可访问网站</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🔧</span>
+    <div class="po-content">
+      <span class="po-label">核心工具</span>
+      <span class="po-value">COCO + HxA Connect</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">📊</span>
+    <div class="po-content">
+      <span class="po-label">核心分工</span>
+      <span class="po-value">协调 · 前端 · 后端 · DevOps · UI/UX · 文案</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">📈</span>
+    <div class="po-content">
+      <span class="po-label">结果</span>
+      <span class="po-value">更小团队，跑出 10 倍产出</span>
+    </div>
+  </div>
+</div>
+
+## 背景：<em>不是多几个工具，而是多了一支 AI 队伍</em>
+
+很多企业开始用 AI，但仍停留在局部提效：写文案更快、写代码更快、客服回复更快。HxA 选择的不是再叠加几个工具，而是把 AI 组织成一支真正可管理的数字团队，让 3-4 人团队也能拥有接近完整产品组织的交付能力。
+
+真正起作用的不是"多写几个 Prompt"，而是明确分工、共享上下文、主动汇报、可直接交接任务的多 Agent 协作系统。Kevin 负责定方向，Jessie 负责调度，前端、后端、DevOps、UI/UX、文案等 Agent 并行执行，形成稳定可复制的企业AI自动化流程。
+
+因此，HxA 这个案例的价值不只是"AI 也能帮忙"，而是展示了企业如何把 AI 从单个助手升级为团队级执行系统。瓶颈不再是模型能不能回答，而是负责人能否高效指挥一支数字团队持续交付。
+
+</div>
+
+<div class="case-section">
+
+## 每天自动运转的 <em>三条协作主线</em>
+
+HxA 的多 Agent 协作不是让 7 个机器人同时说话，而是把复杂交付拆成几条稳定运行的主线：任务拆解与分发、并行执行与同步、上线与复盘。每条主线都有明确 owner，也都有统一的汇报方式。
+
+这套结构的价值不在于炫技，而在于它把传统团队里最耗时间的等待、催进度、补上下文，全部转成了系统化协作。
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">🧠</div>
+    <div class="time-badge">收到任务后立刻</div>
+    <h3>任务拆解</h3>
+    <p>Jessie 接收目标后先做拆解：哪些模块能并行，哪些节点需要人拍板，哪些结果要互相校验。</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">⚙️</div>
+    <div class="time-badge">执行过程中持续</div>
+    <h3>并行执行</h3>
+    <p>前端、后端、设计、文案和部署同时开工，不再按传统的串行交接一个个排队。</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">📣</div>
+    <div class="time-badge">关键节点主动</div>
+    <h3>状态回报</h3>
+    <p>谁完成了什么、卡在哪、下一步是什么，Agent 主动报，不需要 Kevin 逐个追问。</p>
+  </div>
+</div>
+
+结果不是单个人更辛苦，而是整套执行系统更合理、更适合企业AI自动化场景持续复制。
+
+</div>
+
+<div class="case-section">
+
+## 团队架构
+
+HxA 的 7 个 Agent 不是同质化堆叠，而是明确分工后的协作网络。每个角色只管自己最应该负责的部分，避免上下文混乱，也避免多人重复劳动。
+
+和传统组织一样，真正有用的不是人数，而是边界清晰、协作顺畅、输出可追踪。
+
+<table class="arch-table">
+  <thead>
+    <tr>
+      <th>角色</th>
+      <th>负责内容</th>
+      <th>协作方式</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Jessie / Lead Agent</strong></td>
+      <td>任务分发、节奏控制、全局上下文</td>
+      <td>统一协调其余 Agent</td>
+    </tr>
+    <tr>
+      <td><strong>Frontend Agent</strong></td>
+      <td>页面结构、交互、前端实现</td>
+      <td>和 UI/UX、后端并行协同</td>
+    </tr>
+    <tr>
+      <td><strong>Backend Agent</strong></td>
+      <td>接口、数据逻辑、服务能力</td>
+      <td>与前端同步接口规范</td>
+    </tr>
+    <tr>
+      <td><strong>DevOps Agent</strong></td>
+      <td>环境、部署、发布链路</td>
+      <td>承接所有上线动作</td>
+    </tr>
+    <tr>
+      <td><strong>UI/UX Agent</strong></td>
+      <td>视觉方案、组件规范、体验一致性</td>
+      <td>与前端共同收口页面质量</td>
+    </tr>
+    <tr>
+      <td><strong>Copy Agent</strong></td>
+      <td>内容策略、页面文案、品牌语气</td>
+      <td>为产品页、文档、社媒供稿</td>
+    </tr>
+    <tr>
+      <td><strong>Coordinator</strong></td>
+      <td>跨群同步、信息桥接、状态归档</td>
+      <td>保证信息不丢、不乱</td>
+    </tr>
+  </tbody>
+</table>
+
+</div>
+
+<div class="case-section">
+
+<div class="arch-visual">
+  <div class="arch-visual-title">HxA 多 Agent 协作流</div>
+  <div class="arch-flow">
+    <div class="arch-node input">
+      <div class="arch-node-icon">🧭</div>
+      <div class="arch-node-label">Kevin 定方向</div>
+    </div>
+    <div class="arch-arrow"></div>
+    <div class="arch-node core">
+      <div class="arch-node-icon">🐙</div>
+      <div class="arch-node-label">Jessie 调度</div>
+    </div>
+    <div class="arch-arrow"></div>
+    <div class="arch-node output">
+      <div class="arch-node-icon">⚡</div>
+      <div class="arch-node-label">多 Agent 并行交付</div>
+    </div>
+  </div>
+  <div class="arch-sheets">
+    <span class="arch-sheet">前端</span>
+    <span class="arch-sheet">后端</span>
+    <span class="arch-sheet">DevOps</span>
+    <span class="arch-sheet">UI/UX</span>
+    <span class="arch-sheet">文案</span>
+    <span class="arch-sheet">协调</span>
+    <span class="arch-sheet">记忆同步</span>
+  </div>
+  <div class="arch-outputs">
+    <span class="arch-out">📋 主动状态汇报</span>
+    <span class="arch-out">🌐 20 分钟网站上线</span>
+    <span class="arch-out">🧠 跨会话共享上下文</span>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## 结果
+
+HxA 的价值不只是"AI 会写代码"。真正重要的是这支团队能并行、能协作、能在缺少人工盯控的情况下稳定推进。对小团队来说，这种组织杠杆比单点效率提升更关键。
+
+当负责人不再把时间花在转述信息、追进度、补上下文，而是只做方向判断时，交付效率会明显跳升。
+
+<div class="results-grid">
+  <div class="result-card">
+    <div class="result-number">7</div>
+    <div class="result-desc">并行 Agent<br/><small>不是串行问答，而是团队协作</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">20 分钟</div>
+    <div class="result-desc">从想法到上线<br/><small>真实交付，不是概念演示</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">10x</div>
+    <div class="result-desc">团队产出提升<br/><small>3-4 人跑出更大团队效率</small></div>
+  </div>
+</div>
+
+从一个人使用 AI，到一个人管理一支 AI 团队，这就是企业AI自动化最核心的组织跃迁。
+
+</div>
+
+<div class="case-section">
+
+<div class="case-quote">
+  <p>瓶颈不是 AI 的能力，是我自己的调度能力。我现在的瓶颈是我这个人。 — Kevin He, COCO.xyz 创始人</p>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## 为什么这个案例重要
+
+这个案例证明的不是"AI 也能帮点忙"，而是小团队可以把原本需要多人串行完成的工作，改造成可持续运行的多 Agent 组织。这样的组织一旦搭好，价值不是一次性交付，而是之后每一次新任务都能更快启动、更快落地。
+
+对企业来说，最稀缺的往往不是工具，而是可复制的执行能力。HxA 展示的是：把 AI 从"单个助手"升级成"团队基础设施"之后，执行能力可以系统化扩张。
+
+这也是为什么 HxA 的参考意义不只在技术层，而在管理层。清晰分工、主动汇报、交叉校验、共享记忆，这些原本属于团队管理的原则，同样适用于数字员工团队。
+
+</div>
+
+<div class="case-section">
+
+## 常见问题
+
+### Q: 搭建一支像 HxA 这样的 AI 团队需要多久？
+
+如果角色边界和业务流程已经清楚，首版配置通常可以在几天内完成。真正耗时的不是接模型，而是把谁负责什么、怎么协作、什么时候汇报这些管理规则定义清楚。
+
+### Q: HxA Connect 解决了什么问题？
+
+它解决的是 Agent 之间无法直接高效协作的问题。传统聊天工具里，Bot 往往只能跟人互动，信息要靠人中转；而多 Agent 团队要真正并行，Agent 之间必须能直接传递任务、结果和状态。
+
+### Q: 多 Agent 同时运行，怎么避免混乱？
+
+核心不是更多规则，而是更清晰的 ownership。每个模块只有一个 owner，关键产出再由第二个 Agent 复核，负责人只在关键决策点介入。
+
+### Q: 这种模式适合什么团队？
+
+最适合需要同时推进多个模块、但人手有限的小团队，比如产品研发、内容运营、BD、交付团队。只要任务之间存在可并行部分，这种结构都会显著提升吞吐量。
+
+### Q: 它和普通 AI 助手的本质区别是什么？
+
+普通 AI 助手是单线程问答；HxA 这类系统是持续运行的数字团队。它有角色分工、有共享记忆、有主动汇报，也能并行处理不同模块。
+
+### Q: 如何开始搭建自己的多 Agent AI 团队？
+
+访问 coco.xyz 开始免费试用，向 AI Agent 描述你的团队结构和业务流程，它会帮你配置角色、协作规则和汇报流程。全程不需要编程基础。
+
+</div>
+
+<div class="blog-meta">
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Written by</span>
+    <span class="blog-meta-value">COCO Team</span>
+  </div>
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Published on</span>
+    <span class="blog-meta-value">April 2026</span>
+  </div>
+</div>
+
+<div class="case-section">
+  <div class="case-cta">
+    <h2>把 1 个 AI 员工，扩成 1 支可管理的 AI 团队</h2>
+    <p>你负责业务方向，执行、协作与交付交给 COCO。</p>
+    <a href="https://coco.xyz" class="cta-btn">开始试用 COCO</a>
+  </div>
+</div>
+
+<div class="blog-related">
+  <div class="blog-divider-shell">🐚</div>
+  <h3>更多案例</h3>
+  <div class="blog-related-grid">
+    <a class="blog-related-card" href="/zh/case-studies/crm">
+      <div class="blog-related-card-img">📊</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent 案例研究</div>
+        <div class="blog-related-card-title">COCO CRM — AI 搭建，AI 运营</div>
+        <div class="blog-related-card-desc">一套由 AI Agent 从零设计、搭建并每天自动运营的 CRM 系统。</div>
+      </div>
+    </a>
+    <a class="blog-related-card" href="/zh/case-studies/social-media">
+      <div class="blog-related-card-img">📱</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent 案例研究</div>
+        <div class="blog-related-card-title">社媒与 BD 自动化</div>
+        <div class="blog-related-card-desc">从内容发布到商务拓展，一个 AI Agent 替代整条运营流水线。</div>
+      </div>
+    </a>
+    <a class="blog-related-card" href="/zh/case-studies/email-automation">
+      <div class="blog-related-card-img">📧</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent 案例研究</div>
+        <div class="blog-related-card-title">客服邮件自动化</div>
+        <div class="blog-related-card-desc">AI 识别真实用户邮件，自动草拟回复，人工一键确认发送。</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+</div>
+
+<script setup>
+import { onMounted } from 'vue'
+onMounted(() => {
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        e.target.classList.add('visible')
+      }
+    })
+  }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' })
+  document.querySelectorAll('.case-section, .pipeline-card, .result-card, .arch-visual, .case-quote, .case-cta').forEach(el => {
+    el.classList.add('animate-on-scroll')
+    observer.observe(el)
+  })
+  // Pipeline cards get their own animation class
+  document.querySelectorAll('.pipeline-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+  document.querySelectorAll('.result-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+})
+</script>


### PR DESCRIPTION
## Summary
- Add HxA AI Team case study page in English (`docs/case-studies/hxa-team.md`) and Chinese (`docs/zh/case-studies/hxa-team.md`), following the CRM case study template structure
- Add HxA Team entry to sidebar navigation in `config.mjs` (both EN and ZH locales)
- Add HxA Team entry to the mega menu dropdown in `CocoHeader.vue`

### Page content highlights
- SEO-optimized frontmatter with keyword-rich title and OG meta tags
- Full case study structure: hero section, project overview card, three operating lines (task decomposition, parallel execution, proactive reporting), team architecture table, architecture visualization, results cards, quote, FAQ section, related case studies
- Key data points: 7 parallel agents, 20 min idea-to-production, 10x output from 3-4 person team
- Quote: "The bottleneck isn't AI capability. It's my own capacity to direct the team." -- Kevin He

## Test plan
- [ ] Verify EN page renders correctly at `/case-studies/hxa-team`
- [ ] Verify ZH page renders correctly at `/zh/case-studies/hxa-team`
- [ ] Verify HxA Team appears in sidebar under Case Studies (both languages)
- [ ] Verify HxA Team appears in the mega menu dropdown (both languages)
- [ ] Verify all internal links in "More Case Studies" cards work
- [ ] Check mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)