### PR TITLE
docs: redesign landing page and nav for product-value focus

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -72,7 +72,7 @@ export default defineConfig({
 
   vite: {
     server: {
-      allowedHosts: ['zylos100.jinglever.com']
+      allowedHosts: ['zylos100.jinglever.com', 'jessie.coco.site']
     },
   },
 
@@ -140,13 +140,11 @@ export default defineConfig({
       themeConfig: {
         outline: { level: [2, 3] },
         nav: [
-          { text: 'Home', link: '/' },
-          { text: 'Getting Started', link: '/getting-started/' },
           { text: 'Use Cases', link: '/use-cases/' },
           { text: 'Case Studies', link: '/case-studies/' },
-          { text: 'Social Media', link: '/social-media/' },
           { text: 'Channels', link: '/channels/' },
-          { text: 'coco.xyz', link: 'https://coco.xyz' },
+          { text: 'Pricing', link: 'https://coco.xyz/#pricing' },
+          { text: 'Get Started', link: '/getting-started/' },
         ],
         sidebar: {
           '/channels/': [
@@ -283,13 +281,11 @@ export default defineConfig({
       description: 'AI数字员工 — 用例、资源与文档',
       themeConfig: {
         nav: [
-          { text: '首页', link: '/zh/' },
-          { text: '快速开始', link: '/zh/getting-started/' },
-          { text: '用例库', link: '/zh/use-cases/' },
-          { text: '案例研究', link: '/zh/case-studies/' },
-          { text: '社交媒体', link: '/zh/social-media/' },
-          { text: '渠道技巧', link: '/zh/channels/' },
-          { text: 'coco.xyz', link: 'https://coco.xyz' },
+          { text: '用例', link: '/zh/use-cases/' },
+          { text: '案例', link: '/zh/case-studies/' },
+          { text: '渠道', link: '/zh/channels/' },
+          { text: '定价', link: 'https://coco.xyz/#pricing' },
+          { text: '开始使用', link: '/zh/getting-started/' },
         ],
         sidebar: {
           '/zh/channels/': [

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -72,7 +72,7 @@ export default defineConfig({
 
   vite: {
     server: {
-      allowedHosts: ['zylos100.jinglever.com', 'jessie.coco.site']
+      allowedHosts: ['zylos100.jinglever.com']
     },
   },
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -151,6 +151,9 @@ export default defineConfig({
                 { text: 'Telegram', link: '/channels/telegram' },
                 { text: 'Lark / Feishu', link: '/channels/lark' },
                 { text: 'WhatsApp', link: '/channels/whatsapp' },
+                { text: 'WeCom', link: '/getting-started/channel-deployment#option-c-wecom-企业微信-deployment' },
+                { text: 'DingTalk', link: '/getting-started/channel-deployment#option-d-dingtalk-钉钉-deployment' },
+                { text: 'Slack', link: '/getting-started/channel-deployment#slack' },
                 { text: 'Web Console', link: '/channels/web-console' },
               ]
             },
@@ -292,6 +295,9 @@ export default defineConfig({
                 { text: 'Telegram', link: '/zh/channels/telegram' },
                 { text: 'Lark / 飞书', link: '/zh/channels/lark' },
                 { text: 'WhatsApp', link: '/zh/channels/whatsapp' },
+                { text: '企业微信', link: '/zh/getting-started/channel-deployment#option-c-wecom-企业微信-deployment' },
+                { text: '钉钉', link: '/zh/getting-started/channel-deployment#option-d-dingtalk-钉钉-deployment' },
+                { text: 'Slack', link: '/zh/getting-started/channel-deployment#slack' },
                 { text: 'Web 控制台', link: '/zh/channels/web-console' },
               ]
             },

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -70,11 +70,7 @@ export default defineConfig({
     '**/social-media/channels.md',
   ],
 
-  vite: {
-    server: {
-      allowedHosts: ['zylos100.jinglever.com']
-    },
-  },
+  vite: {},
 
   vue: {
     template: {

--- a/docs/.vitepress/theme/CocoHeader.vue
+++ b/docs/.vitepress/theme/CocoHeader.vue
@@ -2,25 +2,28 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useData, useRoute, withBase } from 'vitepress'
 
-const { isDark, lang } = useData()
+const { isDark, lang, theme } = useData()
 const route = useRoute()
 
 const mobileMenuOpen = ref(false)
 const scrolled = ref(false)
 
+// Read nav from VitePress config (single source of truth)
 const navItems = computed(() => {
-  const isZh = lang.value === 'zh-CN'
-  return [
-    { text: isZh ? '用例' : 'Use Cases', link: isZh ? '/zh/use-cases/' : '/use-cases/' },
-    { text: isZh ? '案例' : 'Case Studies', link: isZh ? '/zh/case-studies/' : '/case-studies/' },
-    { text: isZh ? '渠道' : 'Channels', link: isZh ? '/zh/channels/' : '/channels/' },
-    { text: isZh ? '定价' : 'Pricing', link: 'https://coco.xyz/#pricing', external: true },
-  ]
+  const configNav = theme.value.nav || []
+  return configNav
+    .filter(item => item.link && item.text !== 'Get Started' && item.text !== '开始使用')
+    .map(item => ({
+      text: item.text,
+      link: item.link,
+      external: typeof item.link === 'string' && item.link.startsWith('http'),
+    }))
 })
 
 const ctaItem = computed(() => {
-  const isZh = lang.value === 'zh-CN'
-  return { text: isZh ? '开始使用' : 'Get Started', link: isZh ? '/zh/getting-started/' : '/getting-started/' }
+  const configNav = theme.value.nav || []
+  const cta = configNav.find(item => item.text === 'Get Started' || item.text === '开始使用')
+  return cta || { text: lang.value === 'zh-CN' ? '开始使用' : 'Get Started', link: lang.value === 'zh-CN' ? '/zh/getting-started/' : '/getting-started/' }
 })
 
 const currentLang = computed(() => lang.value === 'zh-CN' ? '中文' : 'EN')
@@ -316,7 +319,7 @@ onUnmounted(() => {
   padding: 6px 18px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: #1a1a1a;
+  color: var(--vp-c-bg);
   font-size: 13px;
   font-weight: 600;
   text-decoration: none;
@@ -336,7 +339,7 @@ onUnmounted(() => {
   margin-top: 8px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: #1a1a1a;
+  color: var(--vp-c-bg);
   font-size: 15px;
   font-weight: 600;
   text-decoration: none;

--- a/docs/.vitepress/theme/CocoHeader.vue
+++ b/docs/.vitepress/theme/CocoHeader.vue
@@ -33,8 +33,11 @@ function toggleDark() {
 }
 
 function toggleLang() {
-  const routePath = route.path
-  // Preserve hash and query from current URL
+  // route.path in browser includes base prefix — strip it first
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+  const routePath = base && route.path.startsWith(base)
+    ? route.path.slice(base.length) || '/'
+    : route.path
   const { search, hash } = window.location
   let newPath
   if (lang.value === 'zh-CN') {

--- a/docs/.vitepress/theme/CocoHeader.vue
+++ b/docs/.vitepress/theme/CocoHeader.vue
@@ -322,7 +322,7 @@ onUnmounted(() => {
   padding: 6px 18px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: var(--vp-c-bg);
+  color: #1a1a2e;
   font-size: 13px;
   font-weight: 600;
   text-decoration: none;
@@ -342,7 +342,7 @@ onUnmounted(() => {
   margin-top: 8px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: var(--vp-c-bg);
+  color: #1a1a2e;
   font-size: 15px;
   font-weight: 600;
   text-decoration: none;

--- a/docs/.vitepress/theme/CocoHeader.vue
+++ b/docs/.vitepress/theme/CocoHeader.vue
@@ -12,25 +12,15 @@ const navItems = computed(() => {
   const isZh = lang.value === 'zh-CN'
   return [
     { text: isZh ? '用例' : 'Use Cases', link: isZh ? '/zh/use-cases/' : '/use-cases/' },
+    { text: isZh ? '案例' : 'Case Studies', link: isZh ? '/zh/case-studies/' : '/case-studies/' },
+    { text: isZh ? '渠道' : 'Channels', link: isZh ? '/zh/channels/' : '/channels/' },
     { text: isZh ? '定价' : 'Pricing', link: 'https://coco.xyz/#pricing', external: true },
-    {
-      text: isZh ? '文档' : 'Docs',
-      link: isZh ? '/zh/' : '/',
-      active: true,
-      dropdown: true,
-      sections: [
-        {
-          title: isZh ? '案例研究' : 'Case Studies',
-          items: [
-            { icon: '📊', text: isZh ? 'COCO CRM' : 'COCO CRM', desc: isZh ? 'AI 搭建，AI 运营' : 'Built by AI, Run by AI', link: isZh ? '/zh/case-studies/crm' : '/case-studies/crm' },
-            { icon: '📱', text: isZh ? '社媒自动化' : 'Social Media & BD', desc: isZh ? '两家公司，同一个突破' : 'Two Companies, One Breakthrough', link: isZh ? '/zh/case-studies/social-media' : '/case-studies/social-media' },
-            { icon: '📋', text: isZh ? 'AI 投资尽调' : 'AI Due Diligence', desc: isZh ? '20小时压缩到2小时' : '20 hours down to 2', link: isZh ? '/zh/case-studies/deal-flow-dd' : '/case-studies/deal-flow-dd' },
-            { icon: '📧', text: isZh ? '邮件自动化' : 'Email Automation', desc: isZh ? '真实用户邮件识别、提醒与草稿起草' : 'Detect, alert, and draft replies for real customer emails', link: isZh ? '/zh/case-studies/email-automation' : '/case-studies/email-automation' },
-          ]
-        },
-      ]
-    },
   ]
+})
+
+const ctaItem = computed(() => {
+  const isZh = lang.value === 'zh-CN'
+  return { text: isZh ? '开始使用' : 'Get Started', link: isZh ? '/zh/getting-started/' : '/getting-started/' }
 })
 
 const currentLang = computed(() => lang.value === 'zh-CN' ? '中文' : 'EN')
@@ -80,37 +70,8 @@ onUnmounted(() => {
       <!-- Desktop Nav -->
       <nav class="desktop-nav">
         <template v-for="item in navItems" :key="item.text">
-          <!-- Dropdown nav item -->
-          <div v-if="item.dropdown" class="nav-dropdown">
-            <a :href="withBase(item.link)" class="nav-link dropdown-trigger" :class="{ active: item.active }">
-              {{ item.text }}
-              <svg class="dropdown-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
-            </a>
-            <div class="mega-menu">
-              <div class="mega-menu-inner">
-                <div v-for="section in item.sections" :key="section.title" class="mega-section">
-                  <div class="mega-section-title">{{ section.title }}</div>
-                  <div class="mega-section-grid">
-                    <a
-                      v-for="child in section.items"
-                      :key="child.text"
-                      :href="child.external ? child.link : withBase(child.link)"
-                      :target="child.external ? '_blank' : undefined"
-                      :rel="child.external ? 'noopener' : undefined"
-                      class="mega-item"
-                    >
-                      <span class="mega-item-icon">{{ child.icon }}</span>
-                      <span class="mega-item-text">{{ child.text }}</span>
-                      <span class="mega-item-desc">{{ child.desc }}</span>
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <!-- Regular nav items -->
           <a
-            v-else-if="item.external"
+            v-if="item.external"
             :href="item.link"
             class="nav-link"
             target="_blank"
@@ -120,9 +81,10 @@ onUnmounted(() => {
             v-else
             :href="withBase(item.link)"
             class="nav-link"
-            :class="{ active: item.active }"
           >{{ item.text }}</a>
         </template>
+        <!-- CTA Button -->
+        <a :href="withBase(ctaItem.link)" class="nav-cta">{{ ctaItem.text }}</a>
       </nav>
 
       <!-- Controls -->
@@ -179,31 +141,8 @@ onUnmounted(() => {
     <!-- Mobile Menu -->
     <div class="mobile-menu" v-if="mobileMenuOpen">
       <template v-for="item in navItems" :key="item.text">
-        <!-- Mobile dropdown -->
-        <template v-if="item.dropdown">
-          <div class="mobile-nav-label">{{ item.text }}</div>
-          <template v-for="section in item.sections" :key="section.title">
-            <template v-for="child in section.items" :key="child.text">
-              <a
-                v-if="child.external"
-                :href="child.link"
-                class="mobile-nav-link mobile-nav-child"
-                target="_blank"
-                rel="noopener"
-                @click="mobileMenuOpen = false"
-              >{{ child.icon }} {{ child.text }}</a>
-              <a
-                v-else
-                :href="withBase(child.link)"
-                class="mobile-nav-link mobile-nav-child"
-                @click="mobileMenuOpen = false"
-              >{{ child.icon }} {{ child.text }}</a>
-            </template>
-          </template>
-        </template>
-        <!-- Regular mobile items -->
         <a
-          v-else-if="item.external"
+          v-if="item.external"
           :href="item.link"
           class="mobile-nav-link"
           target="_blank"
@@ -214,10 +153,10 @@ onUnmounted(() => {
           v-else
           :href="withBase(item.link)"
           class="mobile-nav-link"
-          :class="{ active: item.active }"
           @click="mobileMenuOpen = false"
         >{{ item.text }}</a>
       </template>
+      <a :href="withBase(ctaItem.link)" class="mobile-nav-cta" @click="mobileMenuOpen = false">{{ ctaItem.text }}</a>
     </div>
   </header>
 </template>
@@ -370,106 +309,37 @@ onUnmounted(() => {
   color: var(--vp-c-brand-1);
 }
 
-/* Dropdown */
-.nav-dropdown {
-  position: relative;
-}
-.dropdown-trigger {
-  cursor: pointer;
-  display: flex;
+/* Nav CTA Button */
+.nav-cta {
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
-}
-.dropdown-arrow {
-  transition: transform 0.25s ease;
-}
-.nav-dropdown:hover .dropdown-arrow {
-  transform: rotate(180deg);
-}
-
-/* Mega Menu */
-.mega-menu {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  z-index: 50;
-  padding-top: 8px;
-}
-.nav-dropdown:hover .mega-menu,
-.mega-menu:hover {
-  display: block;
-}
-.mega-menu-inner {
-  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
-  border-radius: 16px;
-  padding: 24px 28px;
-  box-shadow: 0 16px 48px rgba(92, 197, 197, 0.15), 0 0 0 1px rgba(92, 197, 197, 0.1);
-}
-.mega-section {
-  margin-bottom: 20px;
-}
-.mega-section:last-child {
-  margin-bottom: 0;
-}
-.mega-section-title {
-  font-size: 11px;
+  padding: 6px 18px;
+  border-radius: 999px;
+  background: var(--vp-c-brand-1);
+  color: #1a1a1a;
+  font-size: 13px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.4);
-  margin-bottom: 12px;
-  padding-left: 4px;
-}
-.mega-section-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 4px;
-}
-.mega-item {
-  display: flex;
-  flex-direction: column;
-  padding: 12px 14px;
-  border-radius: 10px;
   text-decoration: none;
-  transition: background 0.15s;
+  transition: background 0.2s;
+  margin-left: 8px;
+  white-space: nowrap;
 }
-.mega-item:hover {
-  background: rgba(92, 197, 197, 0.12);
-}
-.mega-item-icon {
-  font-size: 1.4rem;
-  margin-bottom: 6px;
-}
-.mega-item-text {
-  font-size: 14px;
-  font-weight: 600;
-  color: #fff;
-  line-height: 1.3;
-}
-.mega-item-desc {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.45);
-  margin-top: 2px;
-  line-height: 1.4;
+.nav-cta:hover {
+  background: var(--vp-c-brand-2);
 }
 
-/* Mobile dropdown */
-.mobile-nav-label {
-  padding: 10px 0 4px;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--vp-c-text-3);
-  border-bottom: none;
-}
-.mobile-nav-child {
-  padding-left: 12px;
-  font-size: 14px;
-  color: var(--vp-c-text-2);
+/* Mobile CTA */
+.mobile-nav-cta {
+  display: block;
+  text-align: center;
+  padding: 12px 0;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: var(--vp-c-brand-1);
+  color: #1a1a1a;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
 }
 
 @media (max-width: 768px) {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,4 +1,5 @@
 /* ===== Font: Plus Jakarta Sans (match dashboard) ===== */
+._cache-bust-20260418 { display: none; }
 @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap');
 
 :root {

--- a/docs/case-studies/crm.md
+++ b/docs/case-studies/crm.md
@@ -27,7 +27,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/case-studies/deal-flow-dd.md
+++ b/docs/case-studies/deal-flow-dd.md
@@ -19,7 +19,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/case-studies/email-automation.md
+++ b/docs/case-studies/email-automation.md
@@ -19,7 +19,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/case-studies/manufacturing-ai.md
+++ b/docs/case-studies/manufacturing-ai.md
@@ -27,7 +27,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/case-studies/manufacturing-ai.md
+++ b/docs/case-studies/manufacturing-ai.md
@@ -1,0 +1,1197 @@
+---
+layout: page
+title: "Manufacturing AI Adoption — From Pain Points to Solutions"
+description: "A traditional manufacturing company's AI selection journey: four real problems, four practical solutions. No dodging hard questions, just solving problems."
+head:
+  - - meta
+    - property: og:title
+      content: "Manufacturing AI Adoption — From Pain Points to Solutions"
+  - - meta
+    - property: og:description
+      content: "A traditional manufacturing company's AI selection journey: four real problems, four practical solutions."
+---
+
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&display=swap');
+
+/* ===== Ocean Palette =====
+   Primary:   #5CC5C5 (teal/turquoise — water)
+   Accent:    #FF7B7B (coral red — crabs/coral)
+   Secondary: #B388D9 (lavender — octopus)
+   Mint:      #A8D8B9 (soft green — seaweed)
+   Warm:      #F5E64D (yellow — from reef text)
+===== */
+
+/* ===== Case Study — Premium Landing ===== */
+.case-hero {
+  position: sticky;
+  top: 64px;
+  z-index: 5;
+  overflow: hidden;
+  padding: 100px 24px 72px;
+  text-align: center;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  border-radius: 0 0 32px 32px;
+  margin: -32px -24px 0;
+}
+.case-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(10, 40, 60, 0.55) 0%,
+    rgba(10, 40, 60, 0.35) 50%,
+    rgba(10, 40, 60, 0.15) 100%
+  );
+  pointer-events: none;
+}
+.case-hero::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: linear-gradient(to top, var(--vp-c-bg), transparent);
+  pointer-events: none;
+}
+.case-hero > * {
+  position: relative;
+  z-index: 1;
+}
+.case-hero .hero-text-box {
+  display: block;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0;
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+}
+.case-body {
+  position: relative;
+  z-index: 10;
+  background: var(--vp-c-bg);
+  padding-top: 48px;
+  margin: 0 -24px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+.case-hero h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 800;
+  line-height: 1.15;
+  color: #fff;
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 16px rgba(0, 0, 0, 0.6), 0 1px 4px rgba(0, 0, 0, 0.5), 0 0 40px rgba(0, 0, 0, 0.3);
+}
+.case-hero h1 em {
+  font-style: normal;
+  color: #A8E8E8;
+  -webkit-text-fill-color: #A8E8E8;
+  text-shadow: 0 2px 20px rgba(92, 197, 197, 0.4), 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+.case-hero .subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  color: #fff;
+  max-width: 640px;
+  margin: 0 auto 32px;
+  line-height: 1.6;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+.case-hero .hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+  flex-wrap: wrap;
+}
+.case-hero .stat {
+  text-align: center;
+}
+.case-hero .stat-value {
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #F5E64D;
+  line-height: 1.1;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+}
+.case-hero .stat-label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Section styling */
+.case-section {
+  max-width: 800px;
+  margin: 0 auto 64px;
+  padding: 0 24px;
+}
+.case-section h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  color: var(--vp-c-text-1);
+}
+.case-section h2 em {
+  font-style: normal;
+  color: #5CC5C5;
+}
+.case-section p {
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--vp-c-text-2);
+  margin-bottom: 1.2em;
+}
+
+/* Pipeline cards — timeline style */
+.pipeline-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 32px 0;
+  position: relative;
+  padding-left: 40px;
+}
+.pipeline-grid::before {
+  content: '';
+  position: absolute;
+  left: 15px;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(to bottom, #5CC5C5, #B388D9, #FF7B7B);
+  border-radius: 2px;
+}
+.pipeline-card {
+  position: relative;
+  padding: 24px 28px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  transition: all 0.3s ease;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+.pipeline-card::before {
+  content: '';
+  position: absolute;
+  left: -33px;
+  top: 32px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #5CC5C5;
+  border: 3px solid var(--vp-c-bg);
+  box-shadow: 0 0 0 2px #5CC5C5;
+  z-index: 1;
+}
+.pipeline-card:nth-child(2)::before { background: #B388D9; box-shadow: 0 0 0 2px #B388D9; }
+.pipeline-card:nth-child(3)::before { background: #FF7B7B; box-shadow: 0 0 0 2px #FF7B7B; }
+.pipeline-card:hover {
+  border-color: #5CC5C5;
+  transform: translateX(4px);
+  box-shadow: 0 8px 32px rgba(92, 197, 197, 0.1);
+}
+.pipeline-card .time-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  font-family: 'Plus Jakarta Sans', monospace;
+  background: rgba(92, 197, 197, 0.1);
+  color: #4BA8A8;
+  margin-bottom: 10px;
+}
+.pipeline-card h3 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--vp-c-text-1);
+}
+.pipeline-card p {
+  font-size: 0.92rem;
+  line-height: 1.65;
+  color: var(--vp-c-text-2);
+  margin: 0;
+}
+.pipeline-card .card-icon {
+  position: absolute;
+  top: 24px;
+  right: 20px;
+  font-size: 2rem;
+  opacity: 0.12;
+}
+@media (max-width: 768px) {
+  .case-hero {
+    position: relative;
+    top: auto;
+    padding: 56px 20px 40px;
+    margin: -16px -16px 0;
+    border-radius: 0 0 20px 20px;
+  }
+  .case-hero h1 {
+    font-size: 1.6rem;
+    margin-bottom: 12px;
+    text-align: center;
+  }
+  .case-hero .subtitle {
+    font-size: 0.9rem;
+    margin-bottom: 20px;
+    line-height: 1.5;
+  }
+  .case-hero .subtitle br { display: none; }
+  .case-hero .hero-stats {
+    gap: 24px;
+  }
+  .case-hero .stat-value {
+    font-size: 1.8rem;
+  }
+  .case-hero .stat-label {
+    font-size: 11px;
+  }
+  .case-body {
+    margin: 0 -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
+  }
+  .case-section {
+    padding: 0 12px;
+    margin-bottom: 40px;
+    text-align: center;
+  }
+  .case-section h2 {
+    font-size: 1.4rem;
+    text-align: center;
+  }
+  .case-section p {
+    font-size: 0.95rem;
+  }
+  .pipeline-grid {
+    text-align: left;
+  }
+  .arch-table {
+    text-align: left;
+  }
+  .pipeline-grid { padding-left: 32px; }
+  .pipeline-card::before { left: -25px; }
+  .pipeline-card {
+    padding: 18px 16px;
+  }
+  .pipeline-card h3 {
+    font-size: 1rem;
+  }
+  .pipeline-card .card-icon {
+    font-size: 1.5rem;
+    top: 18px;
+    right: 14px;
+  }
+  .case-cta {
+    padding: 40px 16px;
+    margin: 32px -16px 0;
+    border-radius: 16px;
+  }
+  .case-cta h2 {
+    font-size: 1.4rem;
+  }
+  .case-quote {
+    padding: 24px 20px 24px 36px;
+  }
+  .arch-table {
+    font-size: 0.85rem;
+  }
+  .arch-table th, .arch-table td {
+    padding: 10px 12px;
+  }
+  .blog-meta {
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+  }
+  .blog-related-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Results block */
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin: 32px 0;
+}
+@media (max-width: 768px) {
+  .results-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px;
+  }
+  .result-card {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    text-align: left;
+    padding: 24px;
+    gap: 16px;
+  }
+  .result-card::after {
+    width: 4px;
+    height: 100%;
+    top: 0;
+    left: 0;
+    right: auto;
+    bottom: 0;
+    border-radius: 20px 0 0 20px;
+  }
+  .result-card .result-number {
+    font-size: 2rem;
+    min-width: 80px;
+    flex-shrink: 0;
+  }
+  .result-card .result-desc {
+    margin-top: 0;
+  }
+}
+.result-card {
+  text-align: center;
+  padding: 36px 24px;
+  border-radius: 20px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  box-shadow: 0 4px 24px rgba(92, 197, 197, 0.06);
+  position: relative;
+  overflow: hidden;
+}
+.result-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #7DD4D4, #A8D8B9);
+  border-radius: 20px 20px 0 0;
+}
+.result-card:nth-child(2)::after {
+  background: linear-gradient(90deg, #B388D9, #D4A8E8);
+}
+.result-card:nth-child(3)::after {
+  background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
+}
+.result-card .result-number {
+  font-size: 2.6rem;
+  font-weight: 800;
+  color: #3BA8A8;
+  line-height: 1.1;
+  font-family: 'Playfair Display', Georgia, serif;
+}
+.result-card:nth-child(2) .result-number { color: #9B6CC4; }
+.result-card:nth-child(3) .result-number { color: #E86060; }
+.result-card .result-desc {
+  font-size: 0.92rem;
+  color: var(--vp-c-text-2);
+  margin-top: 12px;
+  line-height: 1.5;
+}
+
+/* Quote block */
+.case-quote {
+  position: relative;
+  padding: 32px 32px 32px 48px;
+  margin: 40px 0;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(92, 197, 197, 0.06), rgba(179, 136, 217, 0.04));
+  border-left: 4px solid #5CC5C5;
+}
+.case-quote::before {
+  content: '\201C';
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  font-size: 3rem;
+  color: #5CC5C5;
+  opacity: 0.4;
+  line-height: 1;
+  font-family: Georgia, serif;
+}
+.case-quote p {
+  font-size: 1.1rem;
+  font-style: italic;
+  line-height: 1.7;
+  color: var(--vp-c-text-1);
+  margin: 0;
+}
+
+/* CRM architecture table */
+.arch-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 24px 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+}
+.arch-table th {
+  background: rgba(92, 197, 197, 0.1);
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 14px 16px;
+  text-align: left;
+}
+.arch-table td {
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  color: var(--vp-c-text-2);
+  border-top: 1px solid var(--vp-c-divider);
+}
+.arch-table tr:hover td {
+  background: var(--vp-c-bg-soft);
+}
+
+/* Architecture visualization */
+.arch-visual {
+  margin: 32px 0;
+  padding: 32px 24px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  text-align: center;
+  color: #fff;
+}
+.arch-visual-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 24px;
+}
+.arch-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+.arch-node {
+  padding: 16px 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  min-width: 100px;
+}
+.arch-node.input { background: rgba(179, 136, 217, 0.2); }
+.arch-node.core { background: rgba(92, 197, 197, 0.2); border-color: rgba(92, 197, 197, 0.4); }
+.arch-node.output { background: rgba(168, 216, 185, 0.2); }
+.arch-node-icon { font-size: 1.6rem; margin-bottom: 6px; }
+.arch-node-label { font-size: 0.85rem; font-weight: 600; }
+.arch-arrow {
+  width: 32px;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(92, 197, 197, 0.3), #5CC5C5);
+  position: relative;
+}
+.arch-arrow::after {
+  content: '';
+  position: absolute;
+  right: -4px;
+  top: -4px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid #5CC5C5;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+}
+.arch-sheets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.arch-sheet {
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  background: rgba(92, 197, 197, 0.12);
+  color: #7DD4D4;
+  border: 1px solid rgba(92, 197, 197, 0.2);
+}
+.arch-outputs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.arch-out {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+@media (max-width: 640px) {
+  .arch-flow { flex-direction: column; }
+  .arch-arrow { width: 2px; height: 20px; background: linear-gradient(to bottom, rgba(92, 197, 197, 0.3), #5CC5C5); }
+  .arch-arrow::after { right: auto; top: auto; bottom: -4px; left: -4px; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 8px solid #5CC5C5; border-bottom: none; }
+}
+
+/* CTA block */
+.video-showcase {
+  margin: 32px auto 0;
+  max-width: 800px;
+}
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+}
+.video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+}
+
+.case-cta {
+  text-align: center;
+  padding: 64px 24px;
+  margin: 48px -24px 0;
+  background: url('/otter-banner.png') center/cover no-repeat;
+  border-radius: 24px;
+  position: relative;
+  overflow: hidden;
+}
+.case-cta::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 30, 40, 0.45);
+}
+.case-cta > * {
+  position: relative;
+  z-index: 1;
+}
+.case-cta h2 {
+  color: #fff;
+  font-size: 1.8rem;
+  margin-bottom: 12px;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+.case-cta p {
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 28px;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.case-cta .cta-btn {
+  display: inline-block;
+  padding: 14px 36px;
+  border-radius: 999px;
+  background: #5CC5C5;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.case-cta .cta-btn:hover {
+  background: #4BA8A8;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.3);
+}
+
+/* ===== Scroll Animations ===== */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(32px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(32px);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.animate-on-scroll.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.pipeline-card {
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: opacity 0.6s ease, transform 0.6s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.pipeline-card.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+.pipeline-card:nth-child(2) { transition-delay: 0.15s; }
+.pipeline-card:nth-child(3) { transition-delay: 0.3s; }
+.result-card {
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+.result-card.visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.result-card:nth-child(2) { transition-delay: 0.12s; }
+.result-card:nth-child(3) { transition-delay: 0.24s; }
+
+/* ===== Premium Handwritten Font ===== */
+.case-hero h1,
+.case-section h2 {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+}
+.case-hero h1 em,
+.case-section h2 em {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+  font-style: italic;
+}
+
+/* Dark mode fine-tuning */
+.dark .pipeline-card {
+  background: rgba(255, 255, 255, 0.03);
+}
+.dark .result-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* ===== NEW: Blog meta + Related posts ===== */
+.blog-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 0.88rem;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.blog-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-value {
+  color: var(--vp-c-text-2);
+  font-weight: 500;
+}
+
+.blog-related {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  position: relative;
+}
+.blog-divider-shell {
+  position: absolute;
+  top: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 1.6rem;
+  background: var(--vp-c-bg);
+  padding: 0 12px;
+  line-height: 1;
+}
+.blog-related h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  margin: 0 0 24px;
+  text-align: center;
+}
+.blog-related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+.blog-related-card {
+  display: block;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  text-decoration: none;
+  transition: all 0.2s;
+  background: var(--vp-c-bg);
+}
+.blog-related-card:hover {
+  border-color: #5CC5C5;
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.1);
+}
+.blog-related-card-img {
+  height: 160px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 2.5rem;
+  position: relative;
+  overflow: hidden;
+}
+.blog-related-card-img::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  opacity: 0.3;
+}
+.blog-related-card-body {
+  padding: 16px 20px;
+}
+.blog-related-card-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5CC5C5;
+  margin-bottom: 6px;
+}
+.blog-related-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+  margin: 0;
+}
+.blog-related-card-desc {
+  font-size: 0.85rem;
+  color: var(--vp-c-text-3);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+.dark .blog-related-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* ===== Mobile Responsiveness & Visual Polish ===== */
+*, *::before, *::after { box-sizing: border-box; }
+
+/* Prevent horizontal overflow */
+.case-body { overflow-x: hidden; }
+
+/* Table scroll wrapper */
+.arch-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 24px 0;
+}
+.arch-table-wrapper .arch-table { margin: 0; }
+
+/* Better word breaking */
+.case-hero h1, .case-section h2 {
+  word-break: break-word;
+  hyphens: auto;
+}
+
+/* Section max-width for readability */
+.case-section { max-width: 720px; }
+
+/* Section heading accent */
+.case-section h2 {
+  border-left: 4px solid #5CC5C5;
+  padding-left: 16px;
+}
+
+/* Anchor nav scroll offset */
+.case-section h2 { scroll-margin-top: 80px; }
+
+/* Result cards equal height */
+.results-grid { align-items: stretch; }
+
+/* Table zebra striping */
+.arch-table tr:nth-child(even) td { background: var(--vp-c-bg-soft); }
+
+/* Pipeline card left-border accent matching dot color */
+.pipeline-card { border-left: 3px solid #5CC5C5; }
+.pipeline-card:nth-child(2) { border-left-color: #B388D9; }
+.pipeline-card:nth-child(3) { border-left-color: #FF7B7B; }
+
+/* 480px breakpoint */
+@media (max-width: 480px) {
+  .case-hero h1 { font-size: 1.4rem; }
+  .case-hero .hero-stats { gap: 16px; }
+  .case-hero .stat-value { font-size: 1.6rem; }
+  .pipeline-grid { padding-left: 24px; }
+  .pipeline-card::before { left: -17px; }
+  .case-section { padding: 0 8px; }
+  .results-grid { gap: 12px; }
+}
+
+/* ===== Project Overview Card ===== */
+.project-overview {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  margin: 0 0 40px;
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  text-align: left;
+}
+.po-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+}
+.po-icon { font-size: 1.3rem; flex-shrink: 0; line-height: 1.4; }
+.po-content { display: flex; flex-direction: column; min-width: 0; }
+.po-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--vp-c-text-3);
+  margin-bottom: 4px;
+}
+.po-value {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+  word-break: break-word;
+}
+/* FAQ spacing — space between each Q&A pair */
+.case-section h3 {
+  margin-top: 2.5em;
+  margin-bottom: 0.4em;
+}
+.case-section h3:first-child { margin-top: 0; }
+
+@media (max-width: 640px) {
+  .project-overview { grid-template-columns: 1fr; padding: 14px; gap: 8px; }
+  .po-field { padding: 10px 12px; }
+}
+</style>
+
+<div class="case-hero">
+  <div class="hero-text-box">
+    <h1>Manufacturing AI Adoption<br/><em>From Pain Points to Solutions</em></h1>
+    <p class="subtitle">A traditional manufacturer's AI selection journey: four real problems, four practical solutions.<br/>No dodging hard questions, just solving problems.</p>
+    <div class="hero-stats">
+      <div class="stat">
+        <div class="stat-value">4</div>
+        <div class="stat-label">Real Problems</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">4</div>
+        <div class="stat-label">Practical Solutions</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">3</div>
+        <div class="stat-label">Month Evaluation</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="case-body">
+<div class="case-section">
+
+<div class="project-overview">
+  <div class="po-field">
+    <span class="po-icon">🏭</span>
+    <div class="po-content">
+      <span class="po-label">Industry</span>
+      <span class="po-value">Traditional Manufacturing (Paper)</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🏢</span>
+    <div class="po-content">
+      <span class="po-label">Company Size</span>
+      <span class="po-value">Large group, multi-department</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🖥️</span>
+    <div class="po-content">
+      <span class="po-label">Existing Systems</span>
+      <span class="po-value">Yonyou ERP (legacy version)</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">📋</span>
+    <div class="po-content">
+      <span class="po-label">Evaluation Stage</span>
+      <span class="po-value">Selection & testing (2026 Q2)</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🎯</span>
+    <div class="po-content">
+      <span class="po-label">Core Objective</span>
+      <span class="po-value">From 10% automation to full office workflow coverage</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🤝</span>
+    <div class="po-content">
+      <span class="po-label">Engagement Model</span>
+      <span class="po-value">3-month evaluation → pilot departments → full rollout</span>
+    </div>
+  </div>
+</div>
+
+## Background: <em>First Mover in the Industry</em>
+
+This is a large paper manufacturing conglomerate running a legacy Yonyou ERP system for their core business processes. The CEO's vision was crystal clear -- not satisfied with AI replacing just 10% of repetitive work, the goal was to automate the vast majority of daily office operations.
+
+Among their industry peers, they are the first mover. Fellow paper manufacturers are closely watching their results -- the industry has a culture of sharing experiences, and once someone blazes a trail, others follow.
+
+Their selection criteria were equally pragmatic: the product must be mature or near-mature, and once chosen, it would be adopted long-term. They had no appetite for the risks that come with early-stage startup products. They weren't looking for a "demo toy" -- they needed a "production-ready tool."
+
+The value of this case study lies not in showcasing a perfect success story, but in honestly documenting every specific problem a manufacturing enterprise encounters during AI selection -- and how COCO responded.
+
+</div>
+
+<div class="case-section">
+
+## Four Real Problems, <em>Four Practical Solutions</em>
+
+Throughout the evaluation period, the customer raised four core issues. None were theoretical -- each was a real obstacle encountered during actual operations. These problems represent universal challenges that manufacturing enterprises inevitably face during AI adoption.
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">📄</div>
+    <div class="time-badge">Problem 1</div>
+    <h3>Inaccurate OCR Document Recognition</h3>
+    <p>The customer tested AI with 10 photos of delivery notes, asking it to extract data into Excel. Despite clear photos, general-purpose AI produced inaccurate results that recurred after correction. <strong>COCO's approach:</strong> General AI isn't suited for specialized image recognition. Dedicated OCR tools/Skills are needed. The product roadmap already includes document-specific recognition Skills. Short-term solution: integrate professional image recognition toolchains for significantly improved accuracy.</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">🌐</div>
+    <div class="time-badge">Problem 2</div>
+    <h3>Browser Automation Timeout (Banking Sites)</h3>
+    <p>The company needed to log into banking websites that require token/OTP verification, but AI-driven browser operations were too slow -- tokens expired before they could be used. The fundamental issue: websites are designed for humans, not AI. <strong>COCO's approach:</strong> Prioritize API/CLI over browser simulation; use remote desktop assistance (Browser Explorer plugin) for initial login, then maintain the session; pursue a dual strategy -- improve tooling while pushing for API-based banking interfaces.</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">📱</div>
+    <div class="time-badge">Problem 3</div>
+    <h3>Automatic OTP Forwarding</h3>
+    <p>The company phone receives OTP codes that must be manually forwarded to the Agent each time -- a tedious workflow bottleneck. <strong>COCO's approach:</strong> Develop a lightweight Android APK installed on the company phone to intercept SMS messages and automatically forward verification codes to the Agent. With clear requirements, the Agent can even build this APK itself.</p>
+  </div>
+</div>
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">🔒</div>
+    <div class="time-badge">Problem 4</div>
+    <h3>Data Security & Information Isolation</h3>
+    <p>The customer was concerned about AI handling ERP data securely. <strong>COCO's three-layer approach:</strong> Layer 1 -- ISO/SOC2 certification with end-to-end encryption; Layer 2 -- Agent information isolation best practices including personal/business separation, internal/external separation, and inter-department isolation; Layer 3 -- data stays in systems, not in the Agent, with query-only permissions and auditable access control. We were candid: hard isolation remains an industry-wide challenge that even Anthropic/OpenAI haven't fully solved -- we offer current best practices.</p>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## Bonus: <em>The Skill Memory Problem</em>
+
+The customer also raised a practical pain point: they taught the AI a skill, but it forgot by the next day.
+
+This is a real and widespread issue. The current solution involves visual storage (Git/Lark docs) to categorize and record Skills for precise retrieval. The next version of the Workspace product will productize these best practices -- letting users directly see what their Agent knows, what it has learned, and which Skill to use when, eliminating the need to re-teach every time.
+
+<div class="case-quote">
+  <p>We're not looking for a demo toy. We need a production-ready tool. Our industry peers are all watching our results -- once we blaze a trail, others will follow.</p>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## Why This Case Study <em>Matters</em>
+
+This is not a success showcase. It is a complete record of a real vendor selection conversation.
+
+Every problem documented here is a universal challenge that manufacturing enterprises will inevitably face during AI adoption: OCR accuracy, browser automation limitations, authentication workflow gaps, and data security trust thresholds. These problems don't disappear by being avoided -- they are overcome only by being confronted directly.
+
+COCO's approach: don't dodge technical limitations, provide pragmatic solutions, and commit to product iteration timelines. No empty promises about what can't be done yet; clear pathways for what can be achieved.
+
+What makes this particularly noteworthy is the potential industry benchmark effect -- the paper manufacturing sector has a tradition of sharing experiences among peers. The customer's industry contacts are closely watching this experiment. If validated, this isn't just one company's story -- it becomes the starting point for AI adoption across the entire industry.
+
+<div class="results-grid">
+  <div class="result-card">
+    <div class="result-number">4</div>
+    <div class="result-desc">Real Problems<br/><small>From actual operations</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">4</div>
+    <div class="result-desc">Practical Solutions<br/><small>Actionable & pragmatic</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">3 mo</div>
+    <div class="result-desc">Evaluation Period<br/><small>Pilot → full rollout</small></div>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## COCO's <em>Competitive Differentiation</em>
+
+During the selection meeting, the COCO team outlined four core competitive advantages:
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">🧠</div>
+    <div class="time-badge">Advantage 1</div>
+    <h3>Proprietary AI Operating System</h3>
+    <p>COCO has its own AI operating system -- not a wrapper around third-party models. If another provider's model goes offline, COCO keeps running. This is system-level risk resilience.</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">🌏</div>
+    <div class="time-badge">Advantage 2</div>
+    <h3>Singapore-Based, Best Global Models</h3>
+    <p>As a Singapore company, COCO can select the best AI models globally without being restricted to a single region. Whether Claude, GPT, or emerging models -- customers always get the optimal choice.</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">🚀</div>
+    <div class="time-badge">Advantage 3</div>
+    <h3>Enterprise Collaboration Suite Leading the Market</h3>
+    <p>The next version of COCO's enterprise collaboration experience will be 1-2 months ahead of the industry. COCO isn't just an AI tool -- it's a complete system built for enterprise collaboration.</p>
+  </div>
+</div>
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">📊</div>
+    <div class="time-badge">Advantage 4</div>
+    <h3>Growing Vertical Industry Case Library</h3>
+    <p>COCO continues to accumulate real-world deployment cases across industries. Reference case: Width (a KYC SaaS company) -- their non-technical CEO rebuilt an integrated CRM + Zendesk + DocuSign system in just 3-4 days, proving that non-technical users can build complex systems with COCO.</p>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## Frequently Asked Questions
+
+### Q: What level of image recognition accuracy can be achieved?
+
+It depends on the document type and image quality. General-purpose AI has limitations for specialized document recognition, but accuracy improves significantly with dedicated OCR tools. COCO's product roadmap includes purpose-built recognition Skills for various document types (delivery notes, invoices, bills of lading), with continuous optimization.
+
+### Q: Can COCO integrate with existing ERP systems?
+
+Yes. One of AI Agent's core capabilities is acting as a "glue layer" between systems -- it can connect to existing systems via APIs, database connections, or browser automation. The Width case study demonstrates this: a non-technical CEO completed a CRM + Zendesk + DocuSign integration in 3-4 days. Legacy ERP systems like Yonyou can be integrated through similar approaches.
+
+### Q: How is data security ensured?
+
+COCO provides three layers of security: ISO/SOC2 certification with end-to-end encryption; Agent information isolation best practices (personal/business separation, internal/external separation, inter-department isolation); and access control with query-only permissions (data stays in systems, not in the Agent, with auditable retention policies). We are transparent that hard isolation remains an industry-wide challenge -- COCO offers current best-practice solutions.
+
+### Q: Will the Agent forget previously learned skills?
+
+In the current version, Skill persistence is managed through visual storage (Git/Lark docs). The upcoming Workspace product will productize these best practices -- users will be able to directly see their Agent's Skills, when they're used, and how to manage them, fully solving the "taught today, forgotten tomorrow" problem.
+
+### Q: How long does it take from testing to full deployment?
+
+We recommend a phased approach: 3-month evaluation period (validate core scenarios) → pilot departments (select 1-2 departments best suited for automation) → gradual expansion company-wide. This approach minimizes risk, with clear validation metrics at each stage.
+
+### Q: What advantages does COCO have over domestic AI products (like Kimi, Coze)?
+
+Three core differentiators: First, COCO has a proprietary AI operating system rather than being a wrapper, making it independent of any single model provider and more resilient to disruption. Second, as a Singapore company, COCO can access the best global models without regional restrictions. Third, COCO focuses on deep enterprise collaboration -- it's not just a conversational AI, but a complete enterprise solution capable of designing, building, and operating full business systems.
+
+</div>
+
+<div class="blog-meta">
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Written by</span>
+    <span class="blog-meta-value">COCO Team</span>
+  </div>
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Published on</span>
+    <span class="blog-meta-value">April 2026</span>
+  </div>
+</div>
+
+<div class="case-section">
+  <div class="case-cta">
+    <h2>Bring AI to Your Factory Floor</h2>
+    <p>Start with a real problem, find the right solution</p>
+    <a href="https://coco.xyz" class="cta-btn">Try COCO Today</a>
+  </div>
+</div>
+
+<div class="blog-related">
+  <div class="blog-divider-shell">🐚</div>
+  <h3>More Case Studies</h3>
+  <div class="blog-related-grid">
+    <a class="blog-related-card" href="./crm">
+      <div class="blog-related-card-img">🤖</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent Case Study</div>
+        <div class="blog-related-card-title">COCO CRM — Built by AI, Run by AI</div>
+        <div class="blog-related-card-desc">An AI Agent designed a complete CRM in one evening, then runs it daily -- zero manual intervention.</div>
+      </div>
+    </a>
+    <a class="blog-related-card" href="./social-media">
+      <div class="blog-related-card-img">📱</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent Case Study</div>
+        <div class="blog-related-card-title">Social Media & BD Automation</div>
+        <div class="blog-related-card-desc">From content publishing to business development, one AI Agent replaces an entire operations team's workflow.</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+</div>
+
+<script setup>
+import { onMounted } from 'vue'
+onMounted(() => {
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        e.target.classList.add('visible')
+      }
+    })
+  }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' })
+  document.querySelectorAll('.case-section, .pipeline-card, .result-card, .arch-visual, .case-quote, .case-cta').forEach(el => {
+    el.classList.add('animate-on-scroll')
+    observer.observe(el)
+  })
+  document.querySelectorAll('.pipeline-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+  document.querySelectorAll('.result-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+})
+</script>

--- a/docs/case-studies/social-media.md
+++ b/docs/case-studies/social-media.md
@@ -19,7 +19,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -9,6 +9,9 @@ Learn how to get the most out of each communication channel with your COCO AI em
 | [Telegram](./telegram) | International users, personal & team use | ✅ Available |
 | [Lark / Feishu](./lark) | Enterprise teams, document collaboration | ✅ Available |
 | [WhatsApp](./whatsapp) | International business, customer-facing | ✅ Available |
+| [WeCom](../getting-started/channel-deployment#option-c-wecom-企业微信-deployment) | China enterprise teams | ✅ Available |
+| [DingTalk](../getting-started/channel-deployment#option-d-dingtalk-钉钉-deployment) | China enterprise teams | ✅ Available |
+| [Slack](../getting-started/channel-deployment#slack) | International teams, developer workflows | ✅ Available |
 | [Web Console](./web-console) | Browser-based access, testing | ✅ Available |
 
 ## Quick Tips

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,35 +1,382 @@
 ---
 layout: home
 hero:
-  name: "COCO Docs"
-  text: "AI Digital Employee"
-  tagline: "Use Cases, Resources & Documentation"
+  name: "COCO"
+  text: "Your AI Team, Always On"
+  tagline: "AI employees that live in your chat tools — writing docs, crunching data, running operations, closing deals. No setup, no coding. Just results."
+  image:
+    src: /videos/coco-bird-wave.mp4
+    alt: COCO AI
   actions:
     - theme: brand
-      text: Get Started
+      text: Get Started Free
       link: /getting-started/
     - theme: alt
-      text: Browse Use Cases
+      text: See What COCO Can Do
       link: /use-cases/
     - theme: alt
       text: Visit coco.xyz
       link: https://coco.xyz
 
 features:
-  - icon: 🚀
-    title: Getting Started
-    details: Hire your first AI digital employee in minutes. Step-by-step guides for registration, payment, and channel deployment.
-    link: /getting-started/
-  - icon: 📋
-    title: 1,001+ Use Cases
-    details: 1,001+ real-world scenarios across 30 roles and 19 industries. From code review to financial reports — each with demo video and practical prompts.
-    link: /use-cases/
-  - icon: 🎬
-    title: Social Media
-    details: Follow COCO on official channels for the latest updates. Find us on X, Telegram, TikTok, LinkedIn & more.
-    link: /social-media/
-  - icon: 📊
-    title: Case Studies
-    details: 8 core scenarios benchmarked — Code review 4hrs→15min, resume screening 3days→2hrs. 5-10x efficiency gains.
+  - icon: ⚡
+    title: "5-10x Faster, Measured"
+    details: "Code review: 4 hrs → 15 min. Resume screening: 3 days → 2 hrs. Due diligence: 20 hrs → 2 hrs. Not promises — production metrics from real teams."
     link: /case-studies/
+    linkText: See the numbers
+  - icon: 💬
+    title: "Works Where You Work"
+    details: "Telegram, Lark, WhatsApp, Web Console. No new app to install. Just message your AI employee like you'd message a colleague."
+    link: /channels/
+    linkText: View channels
+  - icon: 🎯
+    title: "30 Roles × 19 Industries"
+    details: "1,001+ real scenarios — from Product Manager to Compliance Officer, from SaaS to Manufacturing. Each with prompts you can copy today."
+    link: /use-cases/
+    linkText: Browse use cases
+  - icon: 🔄
+    title: "Not a Chatbot — an Employee"
+    details: "COCO remembers your context, learns your preferences, and gets smarter with use. It doesn't wait for questions — it proactively completes tasks."
+    link: /case-studies/crm
+    linkText: See CRM case study
 ---
+
+<div class="landing-section">
+
+## Proven Results
+
+Real numbers from real teams — not benchmarks, not demos.
+
+<div class="metrics-grid">
+<div class="metric-card">
+<div class="metric-number">15 min</div>
+<div class="metric-label">Code review that took 4 hours</div>
+</div>
+<div class="metric-card">
+<div class="metric-number">2 hrs</div>
+<div class="metric-label">Resume screening that took 3 days</div>
+</div>
+<div class="metric-card">
+<div class="metric-number">10x</div>
+<div class="metric-label">Lead mining: 20/day → 200/day</div>
+</div>
+<div class="metric-card">
+<div class="metric-number">0 hrs</div>
+<div class="metric-label">CRM data entry (was 4 hrs/week)</div>
+</div>
+</div>
+
+</div>
+
+<div class="landing-section">
+
+## How It Works
+
+<div class="steps-grid">
+<div class="step-card">
+<div class="step-number">1</div>
+<div class="step-title">Connect Your Channel</div>
+<div class="step-desc">Add COCO to Telegram, Lark, or WhatsApp. Takes 2 minutes. No API keys, no technical setup.</div>
+</div>
+<div class="step-card">
+<div class="step-number">2</div>
+<div class="step-title">Give a Task</div>
+<div class="step-desc">Message your AI employee in natural language. "Analyze our competitors." "Draft a PRD." "Screen these 200 resumes."</div>
+</div>
+<div class="step-card">
+<div class="step-number">3</div>
+<div class="step-title">Get Results</div>
+<div class="step-desc">COCO delivers complete work — structured reports, formatted documents, analyzed data. Review, iterate, done.</div>
+</div>
+</div>
+
+</div>
+
+<div class="landing-section">
+
+## Case Studies
+
+<div class="cases-grid">
+
+<a href="/case-studies/crm" class="case-card">
+<div class="case-tag">CRM</div>
+<div class="case-title">COCO CRM — Built by AI, Run by AI</div>
+<div class="case-result">Full CRM system built and maintained by AI employees. Auto-syncs calls, emails, and meetings. Data completeness: 61% → 94%.</div>
+</a>
+
+<a href="/case-studies/deal-flow-dd" class="case-card">
+<div class="case-tag">Finance</div>
+<div class="case-title">AI Due Diligence — 20 Hours to 2</div>
+<div class="case-result">Investment due diligence that took a team 20 hours, completed in 2 hours by one person + COCO.</div>
+</a>
+
+<a href="/case-studies/social-media" class="case-card">
+<div class="case-tag">Marketing</div>
+<div class="case-title">Social Media & BD Automation</div>
+<div class="case-result">Content output increased 2.8x. Operations staff freed from production to focus on strategy.</div>
+</a>
+
+<a href="/case-studies/manufacturing-ai" class="case-card">
+<div class="case-tag">Manufacturing</div>
+<div class="case-title">Manufacturing AI Adoption</div>
+<div class="case-result">Traditional manufacturer's journey from ERP to AI — OCR, browser automation, OTP forwarding, data security.</div>
+</a>
+
+</div>
+
+[View all case studies →](/case-studies/)
+
+</div>
+
+<div class="landing-section">
+
+## Deploy Anywhere
+
+COCO works in the tools your team already uses. No context switching.
+
+<div class="channels-grid">
+<a href="/channels/telegram" class="channel-card">
+<div class="channel-icon">✈️</div>
+<div class="channel-name">Telegram</div>
+</a>
+<a href="/channels/lark" class="channel-card">
+<div class="channel-icon">🐦</div>
+<div class="channel-name">Lark / Feishu</div>
+</a>
+<a href="/channels/whatsapp" class="channel-card">
+<div class="channel-icon">💬</div>
+<div class="channel-name">WhatsApp</div>
+</a>
+<a href="/channels/web-console" class="channel-card">
+<div class="channel-icon">🌐</div>
+<div class="channel-name">Web Console</div>
+</a>
+</div>
+
+</div>
+
+<div class="landing-section cta-section">
+
+## Ready to Hire Your AI Team?
+
+Start free. No credit card required. Your first AI employee is 2 minutes away.
+
+<div class="cta-buttons">
+<a href="/getting-started/" class="cta-primary">Get Started Free</a>
+<a href="https://coco.xyz" class="cta-secondary" target="_blank">Learn More at coco.xyz</a>
+</div>
+
+</div>
+
+<style>
+.landing-section {
+  max-width: 1152px;
+  margin: 0 auto;
+  padding: 48px 24px;
+}
+
+.landing-section h2 {
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.landing-section > p {
+  text-align: center;
+  color: var(--vp-c-text-2);
+  margin-bottom: 32px;
+}
+
+/* Metrics */
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+@media (max-width: 768px) {
+  .metrics-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.metric-card {
+  text-align: center;
+  padding: 24px 16px;
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+}
+.metric-number {
+  font-size: 36px;
+  font-weight: 800;
+  color: var(--vp-c-brand-1);
+  line-height: 1.1;
+}
+.metric-label {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  margin-top: 8px;
+  line-height: 1.4;
+}
+
+/* Steps */
+.steps-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+@media (max-width: 768px) {
+  .steps-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.step-card {
+  text-align: center;
+  padding: 32px 24px;
+}
+.step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--vp-c-brand-1);
+  color: #1a1a1a;
+  font-weight: 800;
+  font-size: 18px;
+  margin-bottom: 16px;
+}
+.step-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.step-desc {
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+}
+
+/* Cases */
+.cases-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+@media (max-width: 768px) {
+  .cases-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.case-card {
+  display: block;
+  padding: 24px;
+  border-radius: 12px;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  text-decoration: none;
+  transition: border-color 0.2s, transform 0.2s;
+}
+.case-card:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+}
+.case-tag {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+.case-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  margin-bottom: 8px;
+}
+.case-result {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  line-height: 1.5;
+}
+
+/* Channels */
+.channels-grid {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.channel-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 32px;
+  border-radius: 12px;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  text-decoration: none;
+  transition: border-color 0.2s, transform 0.2s;
+  min-width: 120px;
+}
+.channel-card:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+}
+.channel-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+}
+.channel-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+/* CTA */
+.cta-section {
+  text-align: center;
+  padding: 64px 24px;
+}
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+.cta-primary {
+  display: inline-block;
+  padding: 12px 32px;
+  border-radius: 999px;
+  background: var(--vp-c-brand-1);
+  color: #1a1a1a;
+  font-weight: 600;
+  font-size: 16px;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.cta-primary:hover {
+  background: var(--vp-c-brand-2);
+}
+.cta-secondary {
+  display: inline-block;
+  padding: 12px 32px;
+  border-radius: 999px;
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-1);
+  font-weight: 500;
+  font-size: 16px;
+  text-decoration: none;
+  transition: border-color 0.2s;
+}
+.cta-secondary:hover {
+  border-color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -242,7 +242,7 @@ Start free. No credit card required. Your first AI employee is 2 minutes away.
   height: 40px;
   border-radius: 50%;
   background: var(--vp-c-brand-1);
-  color: var(--vp-c-bg);
+  color: #1a1a2e;
   font-weight: 800;
   font-size: 18px;
   margin-bottom: 16px;
@@ -356,7 +356,7 @@ Start free. No credit card required. Your first AI employee is 2 minutes away.
   padding: 12px 32px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: var(--vp-c-bg);
+  color: #1a1a2e;
   font-weight: 600;
   font-size: 16px;
   text-decoration: none;

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,6 +147,18 @@ COCO works in the tools your team already uses. No context switching.
 <div class="channel-icon">💬</div>
 <div class="channel-name">WhatsApp</div>
 </a>
+<a href="./getting-started/channel-deployment#option-c-wecom-企业微信-deployment" class="channel-card">
+<div class="channel-icon">💼</div>
+<div class="channel-name">WeCom</div>
+</a>
+<a href="./getting-started/channel-deployment#option-d-dingtalk-钉钉-deployment" class="channel-card">
+<div class="channel-icon">🔔</div>
+<div class="channel-name">DingTalk</div>
+</a>
+<a href="./getting-started/channel-deployment#slack" class="channel-card">
+<div class="channel-icon">💜</div>
+<div class="channel-name">Slack</div>
+</a>
 <a href="./channels/web-console" class="channel-card">
 <div class="channel-icon">🌐</div>
 <div class="channel-name">Web Console</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,25 +98,25 @@ Real numbers from real teams — not benchmarks, not demos.
 
 <div class="cases-grid">
 
-<a href="/case-studies/crm" class="case-card">
+<a href="./case-studies/crm" class="case-card">
 <div class="case-tag">CRM</div>
 <div class="case-title">COCO CRM — Built by AI, Run by AI</div>
 <div class="case-result">Full CRM system built and maintained by AI employees. Auto-syncs calls, emails, and meetings. Data completeness: 61% → 94%.</div>
 </a>
 
-<a href="/case-studies/deal-flow-dd" class="case-card">
+<a href="./case-studies/deal-flow-dd" class="case-card">
 <div class="case-tag">Finance</div>
 <div class="case-title">AI Due Diligence — 20 Hours to 2</div>
 <div class="case-result">Investment due diligence that took a team 20 hours, completed in 2 hours by one person + COCO.</div>
 </a>
 
-<a href="/case-studies/social-media" class="case-card">
+<a href="./case-studies/social-media" class="case-card">
 <div class="case-tag">Marketing</div>
 <div class="case-title">Social Media & BD Automation</div>
 <div class="case-result">Content output increased 2.8x. Operations staff freed from production to focus on strategy.</div>
 </a>
 
-<a href="/case-studies/manufacturing-ai" class="case-card">
+<a href="./case-studies/manufacturing-ai" class="case-card">
 <div class="case-tag">Manufacturing</div>
 <div class="case-title">Manufacturing AI Adoption</div>
 <div class="case-result">Traditional manufacturer's journey from ERP to AI — OCR, browser automation, OTP forwarding, data security.</div>
@@ -135,19 +135,19 @@ Real numbers from real teams — not benchmarks, not demos.
 COCO works in the tools your team already uses. No context switching.
 
 <div class="channels-grid">
-<a href="/channels/telegram" class="channel-card">
+<a href="./channels/telegram" class="channel-card">
 <div class="channel-icon">✈️</div>
 <div class="channel-name">Telegram</div>
 </a>
-<a href="/channels/lark" class="channel-card">
+<a href="./channels/lark" class="channel-card">
 <div class="channel-icon">🐦</div>
 <div class="channel-name">Lark / Feishu</div>
 </a>
-<a href="/channels/whatsapp" class="channel-card">
+<a href="./channels/whatsapp" class="channel-card">
 <div class="channel-icon">💬</div>
 <div class="channel-name">WhatsApp</div>
 </a>
-<a href="/channels/web-console" class="channel-card">
+<a href="./channels/web-console" class="channel-card">
 <div class="channel-icon">🌐</div>
 <div class="channel-name">Web Console</div>
 </a>
@@ -162,7 +162,7 @@ COCO works in the tools your team already uses. No context switching.
 Start free. No credit card required. Your first AI employee is 2 minutes away.
 
 <div class="cta-buttons">
-<a href="/getting-started/" class="cta-primary">Get Started Free</a>
+<a href="./getting-started/" class="cta-primary">Get Started Free</a>
 <a href="https://coco.xyz" class="cta-secondary" target="_blank">Learn More at coco.xyz</a>
 </div>
 
@@ -242,7 +242,7 @@ Start free. No credit card required. Your first AI employee is 2 minutes away.
   height: 40px;
   border-radius: 50%;
   background: var(--vp-c-brand-1);
-  color: #1a1a1a;
+  color: var(--vp-c-bg);
   font-weight: 800;
   font-size: 18px;
   margin-bottom: 16px;
@@ -356,7 +356,7 @@ Start free. No credit card required. Your first AI employee is 2 minutes away.
   padding: 12px 32px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: #1a1a1a;
+  color: var(--vp-c-bg);
   font-weight: 600;
   font-size: 16px;
   text-decoration: none;

--- a/docs/index.md
+++ b/docs/index.md
@@ -351,7 +351,8 @@ Start free. No credit card required. Your first AI employee is 2 minutes away.
   margin-top: 24px;
   flex-wrap: wrap;
 }
-.cta-primary {
+.cta-primary,
+.vp-doc .cta-primary {
   display: inline-block;
   padding: 12px 32px;
   border-radius: 999px;
@@ -362,8 +363,10 @@ Start free. No credit card required. Your first AI employee is 2 minutes away.
   text-decoration: none;
   transition: background 0.2s;
 }
-.cta-primary:hover {
+.cta-primary:hover,
+.vp-doc .cta-primary:hover {
   background: var(--vp-c-brand-2);
+  color: #1a1a2e;
 }
 .cta-secondary {
   display: inline-block;

--- a/docs/zh/case-studies/crm.md
+++ b/docs/zh/case-studies/crm.md
@@ -27,7 +27,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/zh/case-studies/deal-flow-dd.md
+++ b/docs/zh/case-studies/deal-flow-dd.md
@@ -19,7 +19,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/zh/case-studies/email-automation.md
+++ b/docs/zh/case-studies/email-automation.md
@@ -19,7 +19,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/zh/case-studies/manufacturing-ai.md
+++ b/docs/zh/case-studies/manufacturing-ai.md
@@ -27,7 +27,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/zh/case-studies/manufacturing-ai.md
+++ b/docs/zh/case-studies/manufacturing-ai.md
@@ -1,0 +1,1197 @@
+---
+layout: page
+title: "制造业 AI 落地实录 — 从痛点到方案"
+description: "一家传统制造企业的 AI 选型之路：四个真实问题，四套落地方案。不回避难题，只解决问题。制造业企业 AI 自动化的完整选型记录。"
+head:
+  - - meta
+    - property: og:title
+      content: "制造业 AI 落地实录 — 从痛点到方案"
+  - - meta
+    - property: og:description
+      content: "一家传统制造企业的 AI 选型之路：四个真实问题，四套落地方案。不回避难题，只解决问题。"
+---
+
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;1,700&display=swap');
+
+/* ===== Ocean Palette =====
+   Primary:   #5CC5C5 (teal/turquoise — water)
+   Accent:    #FF7B7B (coral red — crabs/coral)
+   Secondary: #B388D9 (lavender — octopus)
+   Mint:      #A8D8B9 (soft green — seaweed)
+   Warm:      #F5E64D (yellow — from reef text)
+===== */
+
+/* ===== Case Study — Premium Landing ===== */
+.case-hero {
+  position: sticky;
+  top: 64px;
+  z-index: 5;
+  overflow: hidden;
+  padding: 100px 24px 72px;
+  text-align: center;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  border-radius: 0 0 32px 32px;
+  margin: -32px -24px 0;
+}
+.case-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(10, 40, 60, 0.55) 0%,
+    rgba(10, 40, 60, 0.35) 50%,
+    rgba(10, 40, 60, 0.15) 100%
+  );
+  pointer-events: none;
+}
+.case-hero::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: linear-gradient(to top, var(--vp-c-bg), transparent);
+  pointer-events: none;
+}
+.case-hero > * {
+  position: relative;
+  z-index: 1;
+}
+.case-hero .hero-text-box {
+  display: block;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0;
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+}
+.case-body {
+  position: relative;
+  z-index: 10;
+  background: var(--vp-c-bg);
+  padding-top: 48px;
+  margin: 0 -24px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+.case-hero h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 800;
+  line-height: 1.15;
+  color: #fff;
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 16px rgba(0, 0, 0, 0.6), 0 1px 4px rgba(0, 0, 0, 0.5), 0 0 40px rgba(0, 0, 0, 0.3);
+}
+.case-hero h1 em {
+  font-style: normal;
+  color: #A8E8E8;
+  -webkit-text-fill-color: #A8E8E8;
+  text-shadow: 0 2px 20px rgba(92, 197, 197, 0.4), 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+.case-hero .subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  color: #fff;
+  max-width: 640px;
+  margin: 0 auto 32px;
+  line-height: 1.6;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.4);
+}
+.case-hero .hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+  flex-wrap: wrap;
+}
+.case-hero .stat {
+  text-align: center;
+}
+.case-hero .stat-value {
+  font-size: 2.4rem;
+  font-weight: 800;
+  color: #F5E64D;
+  line-height: 1.1;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+}
+.case-hero .stat-label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Section styling */
+.case-section {
+  max-width: 800px;
+  margin: 0 auto 64px;
+  padding: 0 24px;
+}
+.case-section h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+  color: var(--vp-c-text-1);
+}
+.case-section h2 em {
+  font-style: normal;
+  color: #5CC5C5;
+}
+.case-section p {
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--vp-c-text-2);
+  margin-bottom: 1.2em;
+}
+
+/* Pipeline cards — timeline style */
+.pipeline-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 32px 0;
+  position: relative;
+  padding-left: 40px;
+}
+.pipeline-grid::before {
+  content: '';
+  position: absolute;
+  left: 15px;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(to bottom, #5CC5C5, #B388D9, #FF7B7B);
+  border-radius: 2px;
+}
+.pipeline-card {
+  position: relative;
+  padding: 24px 28px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  transition: all 0.3s ease;
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+.pipeline-card::before {
+  content: '';
+  position: absolute;
+  left: -33px;
+  top: 32px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #5CC5C5;
+  border: 3px solid var(--vp-c-bg);
+  box-shadow: 0 0 0 2px #5CC5C5;
+  z-index: 1;
+}
+.pipeline-card:nth-child(2)::before { background: #B388D9; box-shadow: 0 0 0 2px #B388D9; }
+.pipeline-card:nth-child(3)::before { background: #FF7B7B; box-shadow: 0 0 0 2px #FF7B7B; }
+.pipeline-card:hover {
+  border-color: #5CC5C5;
+  transform: translateX(4px);
+  box-shadow: 0 8px 32px rgba(92, 197, 197, 0.1);
+}
+.pipeline-card .time-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  font-family: 'Plus Jakarta Sans', monospace;
+  background: rgba(92, 197, 197, 0.1);
+  color: #4BA8A8;
+  margin-bottom: 10px;
+}
+.pipeline-card h3 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--vp-c-text-1);
+}
+.pipeline-card p {
+  font-size: 0.92rem;
+  line-height: 1.65;
+  color: var(--vp-c-text-2);
+  margin: 0;
+}
+.pipeline-card .card-icon {
+  position: absolute;
+  top: 24px;
+  right: 20px;
+  font-size: 2rem;
+  opacity: 0.12;
+}
+@media (max-width: 768px) {
+  .case-hero {
+    position: relative;
+    top: auto;
+    padding: 56px 20px 40px;
+    margin: -16px -16px 0;
+    border-radius: 0 0 20px 20px;
+  }
+  .case-hero h1 {
+    font-size: 1.6rem;
+    margin-bottom: 12px;
+    text-align: center;
+  }
+  .case-hero .subtitle {
+    font-size: 0.9rem;
+    margin-bottom: 20px;
+    line-height: 1.5;
+  }
+  .case-hero .subtitle br { display: none; }
+  .case-hero .hero-stats {
+    gap: 24px;
+  }
+  .case-hero .stat-value {
+    font-size: 1.8rem;
+  }
+  .case-hero .stat-label {
+    font-size: 11px;
+  }
+  .case-body {
+    margin: 0 -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
+  }
+  .case-section {
+    padding: 0 12px;
+    margin-bottom: 40px;
+    text-align: center;
+  }
+  .case-section h2 {
+    font-size: 1.4rem;
+    text-align: center;
+  }
+  .case-section p {
+    font-size: 0.95rem;
+  }
+  .pipeline-grid {
+    text-align: left;
+  }
+  .arch-table {
+    text-align: left;
+  }
+  .pipeline-grid { padding-left: 32px; }
+  .pipeline-card::before { left: -25px; }
+  .pipeline-card {
+    padding: 18px 16px;
+  }
+  .pipeline-card h3 {
+    font-size: 1rem;
+  }
+  .pipeline-card .card-icon {
+    font-size: 1.5rem;
+    top: 18px;
+    right: 14px;
+  }
+  .case-cta {
+    padding: 40px 16px;
+    margin: 32px -16px 0;
+    border-radius: 16px;
+  }
+  .case-cta h2 {
+    font-size: 1.4rem;
+  }
+  .case-quote {
+    padding: 24px 20px 24px 36px;
+  }
+  .arch-table {
+    font-size: 0.85rem;
+  }
+  .arch-table th, .arch-table td {
+    padding: 10px 12px;
+  }
+  .blog-meta {
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+  }
+  .blog-related-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Results block */
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin: 32px 0;
+}
+@media (max-width: 768px) {
+  .results-grid {
+    grid-template-columns: 1fr !important;
+    gap: 16px;
+  }
+  .result-card {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    text-align: left;
+    padding: 24px;
+    gap: 16px;
+  }
+  .result-card::after {
+    width: 4px;
+    height: 100%;
+    top: 0;
+    left: 0;
+    right: auto;
+    bottom: 0;
+    border-radius: 20px 0 0 20px;
+  }
+  .result-card .result-number {
+    font-size: 2rem;
+    min-width: 80px;
+    flex-shrink: 0;
+  }
+  .result-card .result-desc {
+    margin-top: 0;
+  }
+}
+.result-card {
+  text-align: center;
+  padding: 36px 24px;
+  border-radius: 20px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  box-shadow: 0 4px 24px rgba(92, 197, 197, 0.06);
+  position: relative;
+  overflow: hidden;
+}
+.result-card::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #7DD4D4, #A8D8B9);
+  border-radius: 20px 20px 0 0;
+}
+.result-card:nth-child(2)::after {
+  background: linear-gradient(90deg, #B388D9, #D4A8E8);
+}
+.result-card:nth-child(3)::after {
+  background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
+}
+.result-card .result-number {
+  font-size: 2.6rem;
+  font-weight: 800;
+  color: #3BA8A8;
+  line-height: 1.1;
+  font-family: 'Playfair Display', Georgia, serif;
+}
+.result-card:nth-child(2) .result-number { color: #9B6CC4; }
+.result-card:nth-child(3) .result-number { color: #E86060; }
+.result-card .result-desc {
+  font-size: 0.92rem;
+  color: var(--vp-c-text-2);
+  margin-top: 12px;
+  line-height: 1.5;
+}
+
+/* Quote block */
+.case-quote {
+  position: relative;
+  padding: 32px 32px 32px 48px;
+  margin: 40px 0;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(92, 197, 197, 0.06), rgba(179, 136, 217, 0.04));
+  border-left: 4px solid #5CC5C5;
+}
+.case-quote::before {
+  content: '\201C';
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  font-size: 3rem;
+  color: #5CC5C5;
+  opacity: 0.4;
+  line-height: 1;
+  font-family: Georgia, serif;
+}
+.case-quote p {
+  font-size: 1.1rem;
+  font-style: italic;
+  line-height: 1.7;
+  color: var(--vp-c-text-1);
+  margin: 0;
+}
+
+/* CRM architecture table */
+.arch-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 24px 0;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+}
+.arch-table th {
+  background: rgba(92, 197, 197, 0.1);
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 14px 16px;
+  text-align: left;
+}
+.arch-table td {
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  color: var(--vp-c-text-2);
+  border-top: 1px solid var(--vp-c-divider);
+}
+.arch-table tr:hover td {
+  background: var(--vp-c-bg-soft);
+}
+
+/* Architecture visualization */
+.arch-visual {
+  margin: 32px 0;
+  padding: 32px 24px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  text-align: center;
+  color: #fff;
+}
+.arch-visual-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 24px;
+}
+.arch-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+.arch-node {
+  padding: 16px 20px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  min-width: 100px;
+}
+.arch-node.input { background: rgba(179, 136, 217, 0.2); }
+.arch-node.core { background: rgba(92, 197, 197, 0.2); border-color: rgba(92, 197, 197, 0.4); }
+.arch-node.output { background: rgba(168, 216, 185, 0.2); }
+.arch-node-icon { font-size: 1.6rem; margin-bottom: 6px; }
+.arch-node-label { font-size: 0.85rem; font-weight: 600; }
+.arch-arrow {
+  width: 32px;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(92, 197, 197, 0.3), #5CC5C5);
+  position: relative;
+}
+.arch-arrow::after {
+  content: '';
+  position: absolute;
+  right: -4px;
+  top: -4px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid #5CC5C5;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+}
+.arch-sheets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.arch-sheet {
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  background: rgba(92, 197, 197, 0.12);
+  color: #7DD4D4;
+  border: 1px solid rgba(92, 197, 197, 0.2);
+}
+.arch-outputs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.arch-out {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+@media (max-width: 640px) {
+  .arch-flow { flex-direction: column; }
+  .arch-arrow { width: 2px; height: 20px; background: linear-gradient(to bottom, rgba(92, 197, 197, 0.3), #5CC5C5); }
+  .arch-arrow::after { right: auto; top: auto; bottom: -4px; left: -4px; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 8px solid #5CC5C5; border-bottom: none; }
+}
+
+/* CTA block */
+.video-showcase {
+  margin: 32px auto 0;
+  max-width: 800px;
+}
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+}
+.video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+}
+
+.case-cta {
+  text-align: center;
+  padding: 64px 24px;
+  margin: 48px -24px 0;
+  background: url('/otter-banner.png') center/cover no-repeat;
+  border-radius: 24px;
+  position: relative;
+  overflow: hidden;
+}
+.case-cta::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 30, 40, 0.45);
+}
+.case-cta > * {
+  position: relative;
+  z-index: 1;
+}
+.case-cta h2 {
+  color: #fff;
+  font-size: 1.8rem;
+  margin-bottom: 12px;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+.case-cta p {
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 28px;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.case-cta .cta-btn {
+  display: inline-block;
+  padding: 14px 36px;
+  border-radius: 999px;
+  background: #5CC5C5;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+.case-cta .cta-btn:hover {
+  background: #4BA8A8;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.3);
+}
+
+/* ===== Scroll Animations ===== */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(32px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(32px);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.animate-on-scroll.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.pipeline-card {
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: opacity 0.6s ease, transform 0.6s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.pipeline-card.visible {
+  opacity: 1;
+  transform: translateX(0);
+}
+.pipeline-card:nth-child(2) { transition-delay: 0.15s; }
+.pipeline-card:nth-child(3) { transition-delay: 0.3s; }
+.result-card {
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+.result-card.visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.result-card:nth-child(2) { transition-delay: 0.12s; }
+.result-card:nth-child(3) { transition-delay: 0.24s; }
+
+/* ===== Premium Handwritten Font ===== */
+.case-hero h1,
+.case-section h2 {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+}
+.case-hero h1 em,
+.case-section h2 em {
+  font-family: 'Playfair Display', Georgia, 'Noto Serif SC', serif;
+  font-style: italic;
+}
+
+/* Dark mode fine-tuning */
+.dark .pipeline-card {
+  background: rgba(255, 255, 255, 0.03);
+}
+.dark .result-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* ===== NEW: Blog meta + Related posts ===== */
+.blog-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 0.88rem;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.blog-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--vp-c-text-3);
+}
+.blog-meta-value {
+  color: var(--vp-c-text-2);
+  font-weight: 500;
+}
+
+.blog-related {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px;
+  border-top: 1px solid var(--vp-c-divider);
+  position: relative;
+}
+.blog-divider-shell {
+  position: absolute;
+  top: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 1.6rem;
+  background: var(--vp-c-bg);
+  padding: 0 12px;
+  line-height: 1;
+}
+.blog-related h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  margin: 0 0 24px;
+  text-align: center;
+}
+.blog-related-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+.blog-related-card {
+  display: block;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--vp-c-divider);
+  text-decoration: none;
+  transition: all 0.2s;
+  background: var(--vp-c-bg);
+}
+.blog-related-card:hover {
+  border-color: #5CC5C5;
+  transform: translateY(-3px);
+  box-shadow: 0 8px 24px rgba(92, 197, 197, 0.1);
+}
+.blog-related-card-img {
+  height: 160px;
+  background: linear-gradient(135deg, #1a3a4a, #1e4d5e);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 2.5rem;
+  position: relative;
+  overflow: hidden;
+}
+.blog-related-card-img::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('/reef-banner.png') center/cover no-repeat;
+  opacity: 0.3;
+}
+.blog-related-card-body {
+  padding: 16px 20px;
+}
+.blog-related-card-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5CC5C5;
+  margin-bottom: 6px;
+}
+.blog-related-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+  margin: 0;
+}
+.blog-related-card-desc {
+  font-size: 0.85rem;
+  color: var(--vp-c-text-3);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+.dark .blog-related-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* ===== Mobile Responsiveness & Visual Polish ===== */
+*, *::before, *::after { box-sizing: border-box; }
+
+/* Prevent horizontal overflow */
+.case-body { overflow-x: hidden; }
+
+/* Table scroll wrapper */
+.arch-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 24px 0;
+}
+.arch-table-wrapper .arch-table { margin: 0; }
+
+/* Better word breaking */
+.case-hero h1, .case-section h2 {
+  word-break: break-word;
+  hyphens: auto;
+}
+
+/* Section max-width for readability */
+.case-section { max-width: 720px; }
+
+/* Section heading accent */
+.case-section h2 {
+  border-left: 4px solid #5CC5C5;
+  padding-left: 16px;
+}
+
+/* Anchor nav scroll offset */
+.case-section h2 { scroll-margin-top: 80px; }
+
+/* Result cards equal height */
+.results-grid { align-items: stretch; }
+
+/* Table zebra striping */
+.arch-table tr:nth-child(even) td { background: var(--vp-c-bg-soft); }
+
+/* Pipeline card left-border accent matching dot color */
+.pipeline-card { border-left: 3px solid #5CC5C5; }
+.pipeline-card:nth-child(2) { border-left-color: #B388D9; }
+.pipeline-card:nth-child(3) { border-left-color: #FF7B7B; }
+
+/* 480px breakpoint */
+@media (max-width: 480px) {
+  .case-hero h1 { font-size: 1.4rem; }
+  .case-hero .hero-stats { gap: 16px; }
+  .case-hero .stat-value { font-size: 1.6rem; }
+  .pipeline-grid { padding-left: 24px; }
+  .pipeline-card::before { left: -17px; }
+  .case-section { padding: 0 8px; }
+  .results-grid { gap: 12px; }
+}
+
+/* ===== Project Overview Card ===== */
+.project-overview {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  margin: 0 0 40px;
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  text-align: left;
+}
+.po-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+}
+.po-icon { font-size: 1.3rem; flex-shrink: 0; line-height: 1.4; }
+.po-content { display: flex; flex-direction: column; min-width: 0; }
+.po-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--vp-c-text-3);
+  margin-bottom: 4px;
+}
+.po-value {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  line-height: 1.4;
+  word-break: break-word;
+}
+/* FAQ spacing — space between each Q&A pair */
+.case-section h3 {
+  margin-top: 2.5em;
+  margin-bottom: 0.4em;
+}
+.case-section h3:first-child { margin-top: 0; }
+
+@media (max-width: 640px) {
+  .project-overview { grid-template-columns: 1fr; padding: 14px; gap: 8px; }
+  .po-field { padding: 10px 12px; }
+}
+</style>
+
+<div class="case-hero">
+  <div class="hero-text-box">
+    <h1>制造业 AI 落地实录<br/><em>从痛点到方案</em></h1>
+    <p class="subtitle">一家传统制造企业的 AI 选型之路：四个真实问题，四套落地方案。<br/>不回避难题，只解决问题。</p>
+    <div class="hero-stats">
+      <div class="stat">
+        <div class="stat-value">4</div>
+        <div class="stat-label">个典型问题</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">4</div>
+        <div class="stat-label">套落地方案</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">3</div>
+        <div class="stat-label">个月选型周期</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="case-body">
+<div class="case-section">
+
+<div class="project-overview">
+  <div class="po-field">
+    <span class="po-icon">🏭</span>
+    <div class="po-content">
+      <span class="po-label">行业</span>
+      <span class="po-value">传统制造业（造纸）</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🏢</span>
+    <div class="po-content">
+      <span class="po-label">企业规模</span>
+      <span class="po-value">大型集团，多部门协同</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🖥️</span>
+    <div class="po-content">
+      <span class="po-label">现有系统</span>
+      <span class="po-value">用友 ERP（传统版本）</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">📋</span>
+    <div class="po-content">
+      <span class="po-label">评估阶段</span>
+      <span class="po-value">选型测试期（2026 Q2）</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🎯</span>
+    <div class="po-content">
+      <span class="po-label">核心诉求</span>
+      <span class="po-value">从 10% 替代到绝大部分办公工作自动化</span>
+    </div>
+  </div>
+  <div class="po-field">
+    <span class="po-icon">🤝</span>
+    <div class="po-content">
+      <span class="po-label">合作模式</span>
+      <span class="po-value">3 个月选型 → 首批部门部署 → 全面推广</span>
+    </div>
+  </div>
+</div>
+
+## 背景：<em>第一个吃螃蟹的人</em>
+
+这是一家传统造纸行业的大型制造集团，内部使用用友老版 ERP 系统管理核心业务流程。老板的目标非常清晰——不满足于 AI 仅仅替代 10% 的重复性工作，而是要替代绝大部分办公室员工的日常工作。
+
+在同行中，他们是第一个吃螃蟹的人。朋友圈里的造纸同行们都在关注他们的尝试结果——这个行业有一个特点，大家愿意互相分享经验，一旦有人趟出来一条路，后面的人会跟上。
+
+选型要求也很务实：产品要足够成熟或半成熟，一旦选定就长期使用，不愿意踩初创产品的坑。他们不是在找一个"能演示的玩具"，而是在找一个"能上生产线的工具"。
+
+这次对话的价值不在于展示一个完美的成功案例，而在于真实记录了制造业企业在 AI 选型过程中遇到的每一个具体问题——以及 COCO 是如何回应的。
+
+</div>
+
+<div class="case-section">
+
+## 四个真实问题与 <em>四套落地方案</em>
+
+在整个选型测试期，客户提出了四个核心问题。每一个都不是理论问题，而是在实际操作中遇到的真实障碍。这些问题也是制造业企业在 AI 落地过程中必然遇到的共性挑战。
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">📄</div>
+    <div class="time-badge">问题 1</div>
+    <h3>OCR 单据识别不准</h3>
+    <p>客户拿 10 张八号单（delivery notes）的照片让 AI 提取数据到 Excel。照片清晰，但通用 AI 裸跑识别仍有偏差，纠正后问题复现。<strong>COCO 方案：</strong>通用 AI 不适合专业图像识别场景，需要配置专业 OCR 工具/Skill。产品路线图已包含单据识别专用 Skill。短期方案：接入更专业的图像识别工具链，显著提升准确率。</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">🌐</div>
+    <div class="time-badge">问题 2</div>
+    <h3>浏览器操作超时（银行网站）</h3>
+    <p>需要登录银行网站执行操作，银行需要 token/OTP 验证，但 AI 操作浏览器太慢，token 还没用就过期了。本质问题：网站是为人类设计的，不是为 AI 设计的。<strong>COCO 方案：</strong>优先使用 API/命令行而非模拟浏览器操作；首次登录用远程桌面辅助（Browser Explorer 插件），登录一次后免登；双向推进——工具端持续改进 + 推动网站端 API 化。</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">📱</div>
+    <div class="time-badge">问题 3</div>
+    <h3>OTP 验证码自动转发</h3>
+    <p>公司手机收到 OTP 验证码，每次都要手动发给 Agent，流程繁琐。<strong>COCO 方案：</strong>开发轻量 Android APK 安装到公司手机，接管短信权限，收到验证码后自动转发给 Agent。需求描述清楚后，Agent 甚至可以直接开发出这个 APK。</p>
+  </div>
+</div>
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">🔒</div>
+    <div class="time-badge">问题 4</div>
+    <h3>数据安全与信息隔离</h3>
+    <p>客户担心 AI 处理 ERP 数据的安全性。<strong>COCO 方案三层防护：</strong>第一层——ISO/SOC2 认证自证清白，全程加密传输；第二层——Agent 信息隔离最佳实践，公私分离、内外分离、部门间隔离；第三层——信息存系统不存 Agent 身上，Agent 只有查询权限，留存需授权且可审计。坦诚说：硬隔离是业界难题，目前只有最佳实践，包括 Anthropic/OpenAI 也没完全解决。</p>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## Bonus：<em>Skill 记忆问题</em>
+
+客户还提出了一个 Agent 使用中的痛点：教会 AI 一个 Skill，隔天就忘了。
+
+这是一个真实且普遍的问题。目前的方案是：用可视化存储（Git/飞书），分门别类记录 Skill，实现精准调用。下一版 Workspace 产品将把这些最佳实践产品化——让用户直接看到 Agent 会什么、学了什么、什么时候用什么 Skill，而不是每次都要重新教。
+
+<div class="case-quote">
+  <p>我们不是在找一个能演示的玩具，是在找一个能上生产线的工具。同行朋友们都在看我们的结果——我们趟出来的路，后面的人会跟上。</p>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## 为什么这个案例 <em>重要</em>
+
+这不是一个展示成功的案例。这是一段真实选型对话的完整记录。
+
+每个问题都是制造业企业在 AI 落地过程中必然遇到的共性挑战：OCR 精度、浏览器自动化的局限、验证码流程的断点、数据安全的信任门槛。这些问题不会因为回避而消失，只会因为正面解决而被克服。
+
+COCO 的回应方式是：不回避技术局限，给出务实方案，承诺产品迭代路线。对于做不到的事情不打包票，对于能做到的事情给出明确路径。
+
+更值得关注的是潜在的行业标杆效应——造纸行业有互相分享经验的传统，客户的同行都在关注这次尝试的结果。一旦验证成功，这不是一家公司的故事，而是整个行业 AI 落地的起点。
+
+<div class="results-grid">
+  <div class="result-card">
+    <div class="result-number">4</div>
+    <div class="result-desc">个真实问题<br/><small>来自实际操作场景</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">4</div>
+    <div class="result-desc">套落地方案<br/><small>务实可执行</small></div>
+  </div>
+  <div class="result-card">
+    <div class="result-number">3 个月</div>
+    <div class="result-desc">选型周期<br/><small>首批部门 → 全面推广</small></div>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## COCO 的 <em>差异化竞争力</em>
+
+在选型会上，COCO 团队总结了四个核心竞争力：
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">🧠</div>
+    <div class="time-badge">竞争力 1</div>
+    <h3>自有 AI 操作系统，非套壳</h3>
+    <p>COCO 拥有自研的 AI 操作系统，不依赖单一模型提供商。别人的模型下线不影响 COCO 运行——系统层面的抗风险能力。</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">🌏</div>
+    <div class="time-badge">竞争力 2</div>
+    <h3>新加坡企业，全球最优模型</h3>
+    <p>作为新加坡企业，COCO 可以选择全球最优的 AI 模型，不受单一地域限制。无论 Claude、GPT 还是其他新兴模型，始终为客户接入最佳选择。</p>
+  </div>
+  <div class="pipeline-card">
+    <div class="card-icon">🚀</div>
+    <div class="time-badge">竞争力 3</div>
+    <h3>企业协作套件持续领先</h3>
+    <p>下一版本的企业协作体验将领先业界 1-2 个月。COCO 不只是 AI 工具，更是一套为企业协作而生的完整系统。</p>
+  </div>
+</div>
+
+<div class="pipeline-grid">
+  <div class="pipeline-card">
+    <div class="card-icon">📊</div>
+    <div class="time-badge">竞争力 4</div>
+    <h3>垂直行业案例持续积累</h3>
+    <p>COCO 持续在各行业积累落地案例。参考案例：Width（KYC SaaS 公司）的非技术 CEO 用 3-4 天重建了 CRM + Zendesk + DocuSign 一体化系统——证明非技术人员也能用 COCO 完成复杂系统搭建。</p>
+  </div>
+</div>
+
+</div>
+
+<div class="case-section">
+
+## 常见问题
+
+### Q: 图像识别准确率能达到多少？
+
+取决于文档类型和图像质量。通用 AI 裸跑在专业单据识别上存在局限，但配置专业 OCR 工具后准确率会显著提升。COCO 的产品路线图已包含针对不同单据类型（如八号单、发票、提货单）的专用识别 Skill，持续优化中。
+
+### Q: 能否对接现有 ERP 系统？
+
+可以。AI Agent 的核心能力之一就是充当系统间的"粘合剂"——它可以通过 API、数据库连接或浏览器操作与已有系统对接。Width 案例证明：一位非技术背景的 CEO 用 3-4 天就完成了 CRM + Zendesk + DocuSign 的一体化系统搭建。用友 ERP 同样可以通过类似方式接入。
+
+### Q: 数据安全如何保障？
+
+COCO 提供三层安全保障：ISO/SOC2 认证 + 全程加密传输、Agent 信息隔离最佳实践（公私分离、内外分离、部门间隔离）、以及查询权限控制（信息存系统不存 Agent，留存需授权且可审计）。我们坦诚地说，硬隔离是业界共同的难题，COCO 提供的是当前最佳实践方案。
+
+### Q: Agent 会忘记之前学到的技能吗？
+
+当前版本中，Skill 的持久化需要通过可视化存储（Git/飞书）来管理。下一版 Workspace 产品将把这些最佳实践产品化——用户可以直接看到 Agent 拥有哪些 Skill、何时调用、如何管理，彻底解决"教了就忘"的问题。
+
+### Q: 从测试到全面部署需要多长时间？
+
+建议采用分阶段推进策略：3 个月选型测试期（验证核心场景）→ 首批部门试点（选择 1-2 个最适合自动化的部门）→ 逐步推广至全公司。这种方式风险最低，每个阶段都有明确的验证指标。
+
+### Q: COCO 与国内 AI 产品（如 Kimi、扣子）相比有什么优势？
+
+核心差异有三点：第一，COCO 拥有自研 AI 操作系统而非套壳，不依赖单一模型提供商，抗风险能力更强；第二，作为新加坡企业可选用全球最优模型，不受地域限制；第三，COCO 专注企业协作深度——不只是对话式 AI，更是一套能设计、搭建、运营完整业务系统的企业级解决方案。
+
+</div>
+
+<div class="blog-meta">
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Written by</span>
+    <span class="blog-meta-value">COCO Team</span>
+  </div>
+  <div class="blog-meta-item">
+    <span class="blog-meta-label">Published on</span>
+    <span class="blog-meta-value">April 2026</span>
+  </div>
+</div>
+
+<div class="case-section">
+  <div class="case-cta">
+    <h2>让 AI 走进你的工厂</h2>
+    <p>从一个真实问题开始，找到属于你的落地方案</p>
+    <a href="https://coco.xyz" class="cta-btn">开始试用 COCO</a>
+  </div>
+</div>
+
+<div class="blog-related">
+  <div class="blog-divider-shell">🐚</div>
+  <h3>更多案例</h3>
+  <div class="blog-related-grid">
+    <a class="blog-related-card" href="./crm">
+      <div class="blog-related-card-img">🤖</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent 案例研究</div>
+        <div class="blog-related-card-title">COCO CRM — 由 AI 搭建，由 AI 运营</div>
+        <div class="blog-related-card-desc">一个 AI Agent 用一个晚上设计了完整 CRM，然后每天自动运营——零人工介入。</div>
+      </div>
+    </a>
+    <a class="blog-related-card" href="./social-media">
+      <div class="blog-related-card-img">📱</div>
+      <div class="blog-related-card-body">
+        <div class="blog-related-card-label">AI Agent 案例研究</div>
+        <div class="blog-related-card-title">社媒与 BD 自动化：AI 全流程运营</div>
+        <div class="blog-related-card-desc">从内容发布到商务拓展，一个 AI Agent 替代整个运营团队的工作流。</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+</div>
+
+<script setup>
+import { onMounted } from 'vue'
+onMounted(() => {
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        e.target.classList.add('visible')
+      }
+    })
+  }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' })
+  document.querySelectorAll('.case-section, .pipeline-card, .result-card, .arch-visual, .case-quote, .case-cta').forEach(el => {
+    el.classList.add('animate-on-scroll')
+    observer.observe(el)
+  })
+  document.querySelectorAll('.pipeline-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+  document.querySelectorAll('.result-card').forEach(el => {
+    el.classList.remove('animate-on-scroll')
+    observer.observe(el)
+  })
+})
+</script>

--- a/docs/zh/case-studies/social-media.md
+++ b/docs/zh/case-studies/social-media.md
@@ -19,7 +19,6 @@ head:
   position: sticky;
   top: 64px;
   z-index: 5;
-  overflow: hidden;
   padding: 100px 24px 72px;
   text-align: center;
   background: url('/reef-banner.png') center/cover no-repeat;

--- a/docs/zh/channels/index.md
+++ b/docs/zh/channels/index.md
@@ -9,6 +9,9 @@
 | [Telegram](./telegram) | 国际用户、个人及团队使用 | ✅ 可用 |
 | [Lark / 飞书](./lark) | 企业团队、文档协作 | ✅ 可用 |
 | [WhatsApp](./whatsapp) | 国际业务、面向客户的场景 | ✅ 可用 |
+| [企业微信](../getting-started/channel-deployment#option-c-wecom-企业微信-deployment) | 国内企业团队 | ✅ 可用 |
+| [钉钉](../getting-started/channel-deployment#option-d-dingtalk-钉钉-deployment) | 国内企业团队 | ✅ 可用 |
+| [Slack](../getting-started/channel-deployment#slack) | 国际团队、开发者工作流 | ✅ 可用 |
 | [Web 控制台](./web-console) | 浏览器访问、快速测试 | ✅ 可用 |
 
 ## 通用技巧

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -351,7 +351,8 @@ COCO 在你团队已有的工具中工作。无需切换。
   margin-top: 24px;
   flex-wrap: wrap;
 }
-.cta-primary {
+.cta-primary,
+.vp-doc .cta-primary {
   display: inline-block;
   padding: 12px 32px;
   border-radius: 999px;
@@ -362,8 +363,10 @@ COCO 在你团队已有的工具中工作。无需切换。
   text-decoration: none;
   transition: background 0.2s;
 }
-.cta-primary:hover {
+.cta-primary:hover,
+.vp-doc .cta-primary:hover {
   background: var(--vp-c-brand-2);
+  color: #1a1a2e;
 }
 .cta-secondary {
   display: inline-block;

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -147,6 +147,18 @@ COCO 在你团队已有的工具中工作。无需切换。
 <div class="channel-icon">💬</div>
 <div class="channel-name">WhatsApp</div>
 </a>
+<a href="./getting-started/channel-deployment#option-c-wecom-企业微信-deployment" class="channel-card">
+<div class="channel-icon">💼</div>
+<div class="channel-name">企业微信</div>
+</a>
+<a href="./getting-started/channel-deployment#option-d-dingtalk-钉钉-deployment" class="channel-card">
+<div class="channel-icon">🔔</div>
+<div class="channel-name">钉钉</div>
+</a>
+<a href="./getting-started/channel-deployment#slack" class="channel-card">
+<div class="channel-icon">💜</div>
+<div class="channel-name">Slack</div>
+</a>
 <a href="./channels/web-console" class="channel-card">
 <div class="channel-icon">🌐</div>
 <div class="channel-name">Web 控制台</div>

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -1,35 +1,382 @@
 ---
 layout: home
 hero:
-  name: "COCO 文档"
-  text: "AI数字员工"
-  tagline: "1,001+ 真实场景用例 · 完整资源库 · 部署文档 · FAQ"
+  name: "COCO"
+  text: "你的 AI 团队，全天候在线"
+  tagline: "AI 员工驻扎在你的聊天工具中 — 写文档、做调研、跑运营、追客户。无需部署，无需代码，只要结果。"
+  image:
+    src: /videos/coco-bird-wave.mp4
+    alt: COCO AI
   actions:
     - theme: brand
-      text: 快速开始
+      text: 免费开始
       link: /zh/getting-started/
     - theme: alt
-      text: 浏览用例
+      text: 看看 COCO 能做什么
       link: /zh/use-cases/
     - theme: alt
       text: 访问 coco.xyz
       link: https://coco.xyz
 
 features:
-  - icon: 🚀
-    title: 快速开始
-    details: 几分钟内雇佣你的第一位AI数字员工。注册、支付、渠道部署全流程指南。
-    link: /zh/getting-started/
-  - icon: 📋
-    title: 1,001+ 用例库
-    details: 覆盖30个角色、19个行业的1,001+个真实场景。从代码审查到财务报告，每个用例都配有演示视频和实用提示词。
-    link: /zh/use-cases/
-  - icon: 🎬
-    title: 社交媒体
-    details: 关注COCO官方渠道，获取最新动态。覆盖X、Telegram、TikTok、LinkedIn等主流平台。
-    link: /zh/social-media/
-  - icon: 📊
-    title: 案例研究
-    details: 8大核心场景实测 — 代码审查4小时→15分钟、简历筛选3天→2小时，效率提升5-10倍。
+  - icon: ⚡
+    title: "5-10 倍提效，有据可查"
+    details: "代码审查：4 小时 → 15 分钟。简历筛选：3 天 → 2 小时。投资尽调：20 小时 → 2 小时。不是承诺，是生产环境的真实数据。"
     link: /zh/case-studies/
+    linkText: 查看数据
+  - icon: 💬
+    title: "在你常用的工具里工作"
+    details: "Telegram、飞书、WhatsApp、Web 控制台。不用装新应用，像给同事发消息一样指挥你的 AI 员工。"
+    link: /zh/channels/
+    linkText: 查看渠道
+  - icon: 🎯
+    title: "30 个角色 × 19 个行业"
+    details: "1,001+ 真实场景 — 从产品经理到合规官，从 SaaS 到制造业。每个场景都有可直接复用的 Prompt。"
+    link: /zh/use-cases/
+    linkText: 浏览用例
+  - icon: 🔄
+    title: "不是聊天机器人，是员工"
+    details: "COCO 记住你的上下文，学习你的偏好，越用越聪明。它不等你提问 — 主动完成任务。"
+    link: /zh/case-studies/crm
+    linkText: 看 CRM 案例
 ---
+
+<div class="landing-section">
+
+## 真实成果
+
+来自真实团队的真实数据 — 不是 benchmark，不是演示。
+
+<div class="metrics-grid">
+<div class="metric-card">
+<div class="metric-number">15 分钟</div>
+<div class="metric-label">原来需要 4 小时的代码审查</div>
+</div>
+<div class="metric-card">
+<div class="metric-number">2 小时</div>
+<div class="metric-label">原来需要 3 天的简历筛选</div>
+</div>
+<div class="metric-card">
+<div class="metric-number">10 倍</div>
+<div class="metric-label">线索挖掘：20条/天 → 200条/天</div>
+</div>
+<div class="metric-card">
+<div class="metric-number">0 小时</div>
+<div class="metric-label">CRM 数据录入（原来每周 4 小时）</div>
+</div>
+</div>
+
+</div>
+
+<div class="landing-section">
+
+## 三步上手
+
+<div class="steps-grid">
+<div class="step-card">
+<div class="step-number">1</div>
+<div class="step-title">接入渠道</div>
+<div class="step-desc">将 COCO 添加到 Telegram、飞书或 WhatsApp。2 分钟完成，无需 API Key，无需技术配置。</div>
+</div>
+<div class="step-card">
+<div class="step-number">2</div>
+<div class="step-title">布置任务</div>
+<div class="step-desc">用自然语言给 AI 员工派活。"分析我们的竞品。" "写一份 PRD。" "筛选这 200 份简历。"</div>
+</div>
+<div class="step-card">
+<div class="step-number">3</div>
+<div class="step-title">收取成果</div>
+<div class="step-desc">COCO 交付完整工作 — 结构化报告、排版好的文档、分析好的数据。你审阅、反馈、完成。</div>
+</div>
+</div>
+
+</div>
+
+<div class="landing-section">
+
+## 客户案例
+
+<div class="cases-grid">
+
+<a href="/zh/case-studies/crm" class="case-card">
+<div class="case-tag">CRM</div>
+<div class="case-title">COCO CRM — AI 搭建，AI 运营</div>
+<div class="case-result">完整 CRM 系统由 AI 员工搭建和维护。自动同步通话、邮件和会议记录。数据完整度：61% → 94%。</div>
+</a>
+
+<a href="/zh/case-studies/deal-flow-dd" class="case-card">
+<div class="case-tag">金融</div>
+<div class="case-title">AI 投资尽调 — 20 小时压缩到 2 小时</div>
+<div class="case-result">一个团队需要 20 小时完成的投资尽调，一个人 + COCO 只用 2 小时。</div>
+</a>
+
+<a href="/zh/case-studies/social-media" class="case-card">
+<div class="case-tag">营销</div>
+<div class="case-title">社媒与 BD 自动化</div>
+<div class="case-result">内容产出量提升 2.8 倍。运营从内容生产中解放，转而聚焦策略。</div>
+</a>
+
+<a href="/zh/case-studies/manufacturing-ai" class="case-card">
+<div class="case-tag">制造业</div>
+<div class="case-title">制造业 AI 落地实录</div>
+<div class="case-result">传统制造企业从 ERP 到 AI 的转型之路 — OCR 识别、浏览器自动化、OTP 转发、数据安全。</div>
+</a>
+
+</div>
+
+[查看全部案例 →](/zh/case-studies/)
+
+</div>
+
+<div class="landing-section">
+
+## 随处部署
+
+COCO 在你团队已有的工具中工作。无需切换。
+
+<div class="channels-grid">
+<a href="/zh/channels/telegram" class="channel-card">
+<div class="channel-icon">✈️</div>
+<div class="channel-name">Telegram</div>
+</a>
+<a href="/zh/channels/lark" class="channel-card">
+<div class="channel-icon">🐦</div>
+<div class="channel-name">飞书 / Lark</div>
+</a>
+<a href="/zh/channels/whatsapp" class="channel-card">
+<div class="channel-icon">💬</div>
+<div class="channel-name">WhatsApp</div>
+</a>
+<a href="/zh/channels/web-console" class="channel-card">
+<div class="channel-icon">🌐</div>
+<div class="channel-name">Web 控制台</div>
+</a>
+</div>
+
+</div>
+
+<div class="landing-section cta-section">
+
+## 准备好组建你的 AI 团队了吗？
+
+免费开始，无需信用卡。2 分钟内拥有你的第一位 AI 员工。
+
+<div class="cta-buttons">
+<a href="/zh/getting-started/" class="cta-primary">免费开始</a>
+<a href="https://coco.xyz" class="cta-secondary" target="_blank">了解更多</a>
+</div>
+
+</div>
+
+<style>
+.landing-section {
+  max-width: 1152px;
+  margin: 0 auto;
+  padding: 48px 24px;
+}
+
+.landing-section h2 {
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.landing-section > p {
+  text-align: center;
+  color: var(--vp-c-text-2);
+  margin-bottom: 32px;
+}
+
+/* Metrics */
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+@media (max-width: 768px) {
+  .metrics-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.metric-card {
+  text-align: center;
+  padding: 24px 16px;
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+}
+.metric-number {
+  font-size: 36px;
+  font-weight: 800;
+  color: var(--vp-c-brand-1);
+  line-height: 1.1;
+}
+.metric-label {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  margin-top: 8px;
+  line-height: 1.4;
+}
+
+/* Steps */
+.steps-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+@media (max-width: 768px) {
+  .steps-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.step-card {
+  text-align: center;
+  padding: 32px 24px;
+}
+.step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--vp-c-brand-1);
+  color: #1a1a1a;
+  font-weight: 800;
+  font-size: 18px;
+  margin-bottom: 16px;
+}
+.step-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.step-desc {
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+}
+
+/* Cases */
+.cases-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+@media (max-width: 768px) {
+  .cases-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.case-card {
+  display: block;
+  padding: 24px;
+  border-radius: 12px;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  text-decoration: none;
+  transition: border-color 0.2s, transform 0.2s;
+}
+.case-card:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+}
+.case-tag {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+.case-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  margin-bottom: 8px;
+}
+.case-result {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  line-height: 1.5;
+}
+
+/* Channels */
+.channels-grid {
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.channel-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 32px;
+  border-radius: 12px;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  text-decoration: none;
+  transition: border-color 0.2s, transform 0.2s;
+  min-width: 120px;
+}
+.channel-card:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+}
+.channel-icon {
+  font-size: 32px;
+  margin-bottom: 8px;
+}
+.channel-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+
+/* CTA */
+.cta-section {
+  text-align: center;
+  padding: 64px 24px;
+}
+.cta-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+.cta-primary {
+  display: inline-block;
+  padding: 12px 32px;
+  border-radius: 999px;
+  background: var(--vp-c-brand-1);
+  color: #1a1a1a;
+  font-weight: 600;
+  font-size: 16px;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.cta-primary:hover {
+  background: var(--vp-c-brand-2);
+}
+.cta-secondary {
+  display: inline-block;
+  padding: 12px 32px;
+  border-radius: 999px;
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-1);
+  font-weight: 500;
+  font-size: 16px;
+  text-decoration: none;
+  transition: border-color 0.2s;
+}
+.cta-secondary:hover {
+  border-color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -98,25 +98,25 @@ features:
 
 <div class="cases-grid">
 
-<a href="/zh/case-studies/crm" class="case-card">
+<a href="./case-studies/crm" class="case-card">
 <div class="case-tag">CRM</div>
 <div class="case-title">COCO CRM — AI 搭建，AI 运营</div>
 <div class="case-result">完整 CRM 系统由 AI 员工搭建和维护。自动同步通话、邮件和会议记录。数据完整度：61% → 94%。</div>
 </a>
 
-<a href="/zh/case-studies/deal-flow-dd" class="case-card">
+<a href="./case-studies/deal-flow-dd" class="case-card">
 <div class="case-tag">金融</div>
 <div class="case-title">AI 投资尽调 — 20 小时压缩到 2 小时</div>
 <div class="case-result">一个团队需要 20 小时完成的投资尽调，一个人 + COCO 只用 2 小时。</div>
 </a>
 
-<a href="/zh/case-studies/social-media" class="case-card">
+<a href="./case-studies/social-media" class="case-card">
 <div class="case-tag">营销</div>
 <div class="case-title">社媒与 BD 自动化</div>
 <div class="case-result">内容产出量提升 2.8 倍。运营从内容生产中解放，转而聚焦策略。</div>
 </a>
 
-<a href="/zh/case-studies/manufacturing-ai" class="case-card">
+<a href="./case-studies/manufacturing-ai" class="case-card">
 <div class="case-tag">制造业</div>
 <div class="case-title">制造业 AI 落地实录</div>
 <div class="case-result">传统制造企业从 ERP 到 AI 的转型之路 — OCR 识别、浏览器自动化、OTP 转发、数据安全。</div>
@@ -135,19 +135,19 @@ features:
 COCO 在你团队已有的工具中工作。无需切换。
 
 <div class="channels-grid">
-<a href="/zh/channels/telegram" class="channel-card">
+<a href="./channels/telegram" class="channel-card">
 <div class="channel-icon">✈️</div>
 <div class="channel-name">Telegram</div>
 </a>
-<a href="/zh/channels/lark" class="channel-card">
+<a href="./channels/lark" class="channel-card">
 <div class="channel-icon">🐦</div>
 <div class="channel-name">飞书 / Lark</div>
 </a>
-<a href="/zh/channels/whatsapp" class="channel-card">
+<a href="./channels/whatsapp" class="channel-card">
 <div class="channel-icon">💬</div>
 <div class="channel-name">WhatsApp</div>
 </a>
-<a href="/zh/channels/web-console" class="channel-card">
+<a href="./channels/web-console" class="channel-card">
 <div class="channel-icon">🌐</div>
 <div class="channel-name">Web 控制台</div>
 </a>
@@ -162,7 +162,7 @@ COCO 在你团队已有的工具中工作。无需切换。
 免费开始，无需信用卡。2 分钟内拥有你的第一位 AI 员工。
 
 <div class="cta-buttons">
-<a href="/zh/getting-started/" class="cta-primary">免费开始</a>
+<a href="./getting-started/" class="cta-primary">免费开始</a>
 <a href="https://coco.xyz" class="cta-secondary" target="_blank">了解更多</a>
 </div>
 
@@ -242,7 +242,7 @@ COCO 在你团队已有的工具中工作。无需切换。
   height: 40px;
   border-radius: 50%;
   background: var(--vp-c-brand-1);
-  color: #1a1a1a;
+  color: var(--vp-c-bg);
   font-weight: 800;
   font-size: 18px;
   margin-bottom: 16px;
@@ -356,7 +356,7 @@ COCO 在你团队已有的工具中工作。无需切换。
   padding: 12px 32px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: #1a1a1a;
+  color: var(--vp-c-bg);
   font-weight: 600;
   font-size: 16px;
   text-decoration: none;

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -242,7 +242,7 @@ COCO 在你团队已有的工具中工作。无需切换。
   height: 40px;
   border-radius: 50%;
   background: var(--vp-c-brand-1);
-  color: var(--vp-c-bg);
+  color: #1a1a2e;
   font-weight: 800;
   font-size: 18px;
   margin-bottom: 16px;
@@ -356,7 +356,7 @@ COCO 在你团队已有的工具中工作。无需切换。
   padding: 12px 32px;
   border-radius: 999px;
   background: var(--vp-c-brand-1);
-  color: var(--vp-c-bg);
+  color: #1a1a2e;
   font-weight: 600;
   font-size: 16px;
   text-decoration: none;


### PR DESCRIPTION
## Summary
- **Landing page**: Shift from docs index to product-value storytelling — hero with value proposition, metrics cards, 3-step onboarding, case study grid, channel cards, and CTA
- **Navigation**: Remove redundant "Docs" dropdown, promote Case Studies and Channels to top-level, add "Get Started" CTA button
- **Both EN and ZH** versions updated

## Preview
https://jessie.coco.site/docs-preview/

## Files Changed
- `docs/index.md` — EN landing page redesign
- `docs/zh/index.md` — ZH landing page redesign  
- `docs/.vitepress/theme/CocoHeader.vue` — Nav restructure + CTA button
- `docs/.vitepress/config.mjs` — Nav items update

## Test plan
- [ ] Verify landing page renders correctly (hero, metrics, steps, cases, channels, CTA)
- [ ] Verify nav items: Use Cases | Case Studies | Channels | Pricing | [Get Started]
- [ ] Verify ZH version at /zh/
- [ ] Check mobile responsive layout
- [ ] Verify all internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)