### PR TITLE
Remove dead YouTube video from social media case study

### DIFF
--- a/docs/case-studies/social-media.md
+++ b/docs/case-studies/social-media.md
@@ -839,12 +839,6 @@ head:
 
 The bottleneck was the same: **more content to produce, more channels to cover, not enough people.**
 
-<div class="video-showcase">
-  <div class="video-container">
-    <iframe src="https://www.youtube.com/embed/jFGNry0BohA" title="COCO Social Media Automation Demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  </div>
-</div>
-
 </div>
 
 <div class="case-section">

--- a/docs/zh/case-studies/social-media.md
+++ b/docs/zh/case-studies/social-media.md
@@ -839,12 +839,6 @@ head:
 
 瓶颈是一样的：**更多内容要出、更多渠道要覆盖、人不够用。**
 
-<div class="video-showcase">
-  <div class="video-container">
-    <iframe src="https://www.youtube.com/embed/jFGNry0BohA" title="COCO 社媒自动化演示" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  </div>
-</div>
-
 </div>
 
 <div class="case-section">


### PR DESCRIPTION
## Summary

- The YouTube video (`jFGNry0BohA`) embedded in the social media case study page has been deleted and shows a broken player
- Removed the dead video embed from both the English (`docs/case-studies/social-media.md`) and Chinese (`docs/zh/case-studies/social-media.md`) versions
- No replacement video — just a clean removal of the broken embed

## Test plan

- [ ] Verify https://docs.coco.xyz/case-studies/social-media no longer shows a broken video player
- [ ] Verify https://docs.coco.xyz/zh/case-studies/social-media no longer shows a broken video player
- [ ] Confirm page layout still looks correct without the video section

🤖 Generated with [Claude Code](https://claude.com/claude-code)