### PR TITLE
fix: use sans-serif font for result-number cards

### DIFF
--- a/docs/case-studies/building-materials.md
+++ b/docs/case-studies/building-materials.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/crm.md
+++ b/docs/case-studies/crm.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -391,7 +392,7 @@ head:
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/fmcg-collaboration.md
+++ b/docs/case-studies/fmcg-collaboration.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/game-studio.md
+++ b/docs/case-studies/game-studio.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/hxa-team.md
+++ b/docs/case-studies/hxa-team.md
@@ -395,6 +395,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -434,7 +435,7 @@ head:
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/manufacturing-ai.md
+++ b/docs/case-studies/manufacturing-ai.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -391,7 +392,7 @@ head:
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/regtech-company.md
+++ b/docs/case-studies/regtech-company.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/shipping-group.md
+++ b/docs/case-studies/shipping-group.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/case-studies/tea-brand-franchise.md
+++ b/docs/case-studies/tea-brand-franchise.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/building-materials.md
+++ b/docs/zh/case-studies/building-materials.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/crm.md
+++ b/docs/zh/case-studies/crm.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -391,7 +392,7 @@ head:
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/fmcg-collaboration.md
+++ b/docs/zh/case-studies/fmcg-collaboration.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/game-studio.md
+++ b/docs/zh/case-studies/game-studio.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/hxa-team.md
+++ b/docs/zh/case-studies/hxa-team.md
@@ -395,6 +395,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -434,7 +435,7 @@ head:
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/manufacturing-ai.md
+++ b/docs/zh/case-studies/manufacturing-ai.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -391,7 +392,7 @@ head:
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/regtech-company.md
+++ b/docs/zh/case-studies/regtech-company.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/shipping-group.md
+++ b/docs/zh/case-studies/shipping-group.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }

--- a/docs/zh/case-studies/tea-brand-franchise.md
+++ b/docs/zh/case-studies/tea-brand-franchise.md
@@ -352,6 +352,7 @@ head:
     border-radius: 20px 0 0 20px;
   }
   .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
     font-size: 2rem;
     min-width: 80px;
     flex-shrink: 0;
@@ -387,11 +388,11 @@ head:
   background: linear-gradient(90deg, #FF7B7B, #FFB3B3);
 }
 .result-card .result-number {
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, 'Noto Sans SC', sans-serif;
   font-size: 2.6rem;
   font-weight: 800;
   color: #3BA8A8;
   line-height: 1.1;
-  font-family: 'Playfair Display', Georgia, serif;
 }
 .result-card:nth-child(2) .result-number { color: #9B6CC4; }
 .result-card:nth-child(3) .result-number { color: #E86060; }


### PR DESCRIPTION
## Summary
- result-number 数据卡片原本使用 Playfair Display 衬线字体，中文字符和 `~` 符号渲染效果不佳（字号不一致）
- 改为 Plus Jakarta Sans + Noto Sans SC（无衬线），中英文和特殊符号显示统一
- 涉及 12 个文件（6 个 EN + 6 个 ZH 标杆案例页面）

## Test plan
- [ ] 检查各标杆案例页面的数字卡片字体是否统一
- [ ] 确认中文字符和 `~` 符号大小一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)