### PR TITLE
docs: replace icoco.ai links with openmax.com equivalents

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -4,7 +4,7 @@ const base = process.env.VITEPRESS_BASE || '/'
 
 const basePrefix = base !== '/' ? base.replace(/\/$/, '') : ''
 
-const docsOrigin = 'https://docs.icoco.ai'
+const docsOrigin = 'https://docs.openmax.com'
 const openMaxIdentity = Object.freeze({
   name: 'OpenMax',
   website: 'https://openmax.com/',

--- a/docs/case-studies/browser-automation.md
+++ b/docs/case-studies/browser-automation.md
@@ -99,7 +99,7 @@ After installation, simply tell your AI Employee what you need in natural langua
 ### Screenshots
 
 ```
-Open https://icoco.ai and send me a screenshot
+Open https://openmax.com and send me a screenshot
 ```
 
 ```
@@ -190,4 +190,4 @@ A: Tell your AI Employee "The browser component installation failed, help me tro
 
 ---
 
-Learn more: [icoco.ai](https://icoco.ai) Contact us: support@icoco.ai
+Learn more: [openmax.com](https://openmax.com) Contact us: support@icoco.ai

--- a/docs/case-studies/building-materials.md
+++ b/docs/case-studies/building-materials.md
@@ -11,7 +11,7 @@ head:
       content: "200+ daily WhatsApp messages, a 30-invoice-per-day human ceiling, and SGD 3–5K QS outsourcing fees with 5–7 day turnarounds. How a Singapore building materials distributor used OpenMax AI to achieve near-zero missed orders, multiply invoice throughput, and compress quantity surveying from a week to hours."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -882,7 +882,7 @@ The annualized savings from eliminating QS outsourcing alone represent a signifi
   <div class="case-cta">
     <h2>Let AI Transform Your Operations</h2>
     <p>From message triage to smart quoting — start with a single conversation</p>
-    <a href="https://icoco.ai" class="cta-btn">Get Started with OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">Get Started with OpenMax</a>
   </div>
 </div>
 

--- a/docs/case-studies/crm.md
+++ b/docs/case-studies/crm.md
@@ -11,7 +11,7 @@ head:
       content: "AI Agent designs, builds, and operates a full CRM — 33% conversion, zero daily maintenance. Real enterprise AI automation case study."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1041,7 +1041,7 @@ OpenMax AI's advantages: fully customized, extremely low cost, deep integration 
 
 ### Q: How do I get OpenMax AI Agent to automatically operate my company's CRM?
 
-Simply visit icoco.ai to start a free trial, describe your business requirements and existing data structure to the AI Agent, and it will help you design the table architecture, build automation workflows, and configure trigger rules. No programming background required — the entire process is completed through natural language conversation with the OpenMax AI Agent.
+Simply visit openmax.com to start a free trial, describe your business requirements and existing data structure to the AI Agent, and it will help you design the table architecture, build automation workflows, and configure trigger rules. No programming background required — the entire process is completed through natural language conversation with the OpenMax AI Agent.
 
 </div>
 
@@ -1060,7 +1060,7 @@ Simply visit icoco.ai to start a free trial, describe your business requirements
   <div class="case-cta">
     <h2>Let AI Build Your Operations System</h2>
     <p>Like OpenMax, start with a single requirements description</p>
-    <a href="https://icoco.ai" class="cta-btn">Try OpenMax Free</a>
+    <a href="https://openmax.com" class="cta-btn">Try OpenMax Free</a>
   </div>
 </div>
 

--- a/docs/case-studies/deal-flow-dd.md
+++ b/docs/case-studies/deal-flow-dd.md
@@ -11,7 +11,7 @@ head:
       content: "AI Agent automates investment due diligence end-to-end: data room to IC memo in 2 hours instead of 20. 3x quarterly deal throughput."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1163,7 +1163,7 @@ Full implementation — from initial configuration through first live deal — t
   <div class="case-cta">
     <h2>Let AI Take Over Your Data Room</h2>
     <p>Focus on finding the next great deal — leave the documents to OpenMax</p>
-    <a href="https://icoco.ai" class="cta-btn">Try OpenMax Free</a>
+    <a href="https://openmax.com" class="cta-btn">Try OpenMax Free</a>
   </div>
 </div>
 

--- a/docs/case-studies/email-automation.md
+++ b/docs/case-studies/email-automation.md
@@ -11,7 +11,7 @@ head:
       content: "AI Agent scans inboxes every 10 minutes, classifies and drafts replies — humans review before sending. Real enterprise email automation case study."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1076,7 +1076,7 @@ The standard setup process involves five steps: (1) provide the email credential
   <div class="case-cta">
     <h2>Let AI Guard Your Inbox</h2>
     <p>Every user email caught. Every reply quality-checked by you.</p>
-    <a href="https://icoco.ai" class="cta-btn">Try OpenMax Free</a>
+    <a href="https://openmax.com" class="cta-btn">Try OpenMax Free</a>
   </div>
 </div>
 

--- a/docs/case-studies/fmcg-collaboration.md
+++ b/docs/case-studies/fmcg-collaboration.md
@@ -11,7 +11,7 @@ head:
       content: "How a top FMCG company operating across 10+ Southeast Asian markets used OpenMax AI inside Lark to auto-dispatch tasks from 5–6 chat groups, enable real-time multilingual coordination, and pass a rigorous three-department security review with private GCP Singapore deployment."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -876,7 +876,7 @@ What makes this deployment particularly significant is the security validation. 
   <div class="case-cta">
     <h2>Bring AI to Your Enterprise Collaboration</h2>
     <p>Like this FMCG leader, start with the tools your team already uses</p>
-    <a href="https://icoco.ai" class="cta-btn">Get Started with OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">Get Started with OpenMax</a>
   </div>
 </div>
 

--- a/docs/case-studies/game-studio.md
+++ b/docs/case-studies/game-studio.md
@@ -11,7 +11,7 @@ head:
       content: "How a sub-10-person game studio used OpenMax AI to build an Agentic OS on Google Workspace, deploy 3 AI employees across development, marketing, and user operations, and make the leap from 'using AI tools' to running an AI-native organization."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -878,7 +878,7 @@ This game studio proves that a sub-10-person team can build an AI-native operati
   <div class="case-cta">
     <h2>Build Your AI-Native Organization</h2>
     <p>Start with a unified AI operating layer — like this studio did</p>
-    <a href="https://icoco.ai" class="cta-btn">Get Started with OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">Get Started with OpenMax</a>
   </div>
 </div>
 

--- a/docs/case-studies/hxa-team.md
+++ b/docs/case-studies/hxa-team.md
@@ -11,7 +11,7 @@ head:
       content: "7 specialized AI Agents run in parallel — from idea to live website in 20 minutes. Multi-agent enterprise automation case study."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1098,7 +1098,7 @@ A normal assistant is reactive and single-threaded. A system like HxA is a conti
 
 ### Q: How do I get started with a multi-agent AI team?
 
-Visit icoco.ai to start a free trial. Describe your team structure and workflows to the AI Agent, and it will help you configure roles, coordination rules, and reporting flows. No programming background required.
+Visit openmax.com to start a free trial. Describe your team structure and workflows to the AI Agent, and it will help you configure roles, coordination rules, and reporting flows. No programming background required.
 
 </div>
 
@@ -1117,7 +1117,7 @@ Visit icoco.ai to start a free trial. Describe your team structure and workflows
   <div class="case-cta">
     <h2>Start with one AI employee, then scale into a team.</h2>
     <p>You set the direction. A manageable AI team handles execution.</p>
-    <a href="https://icoco.ai" class="cta-btn">Try OpenMax Free</a>
+    <a href="https://openmax.com" class="cta-btn">Try OpenMax Free</a>
   </div>
 </div>
 

--- a/docs/case-studies/index.md
+++ b/docs/case-studies/index.md
@@ -168,4 +168,4 @@ OpenMax is not a chatbot — it's your full-time AI employee. Send a message via
 
 ---
 
-Learn more: [icoco.ai](https://icoco.ai) | Contact us: support@icoco.ai
+Learn more: [openmax.com](https://openmax.com) | Contact us: support@icoco.ai

--- a/docs/case-studies/manufacturing-ai.md
+++ b/docs/case-studies/manufacturing-ai.md
@@ -11,7 +11,7 @@ head:
       content: "Manufacturing AI case study: four real pain points, four practical AI solutions. Enterprise AI automation that actually works on the factory floor."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1027,7 +1027,7 @@ In the current version, Skill persistence is managed through visual storage (Git
   <div class="case-cta">
     <h2>Bring AI to Your Factory Floor</h2>
     <p>Start with a real problem, find the right solution</p>
-    <a href="https://icoco.ai" class="cta-btn">Try OpenMax Today</a>
+    <a href="https://openmax.com" class="cta-btn">Try OpenMax Today</a>
   </div>
 </div>
 

--- a/docs/case-studies/regtech-company.md
+++ b/docs/case-studies/regtech-company.md
@@ -11,7 +11,7 @@ head:
       content: "A RegTech firm selling AI compliance platforms to banks across Asia-Pacific and the Middle East — but running its own marketing and operations manually. How OpenMax AI unified three fragmented systems, automated regulatory push, and enabled the company to operate the way it advises its clients to."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -878,7 +878,7 @@ What OpenMax enabled was not just operational improvement but strategic alignmen
   <div class="case-cta">
     <h2>Practice What You Preach</h2>
     <p>Bring AI into your own operations — the way you advise your clients to</p>
-    <a href="https://icoco.ai" class="cta-btn">Get Started with OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">Get Started with OpenMax</a>
   </div>
 </div>
 

--- a/docs/case-studies/seedance-video.md
+++ b/docs/case-studies/seedance-video.md
@@ -102,7 +102,7 @@ The OpenMax AI Employee will invoke the Seedance Skill to output a professional 
 
 Review the prompt and modify as needed. For example:
 
-- "Add icoco.ai URL at the end"
+- "Add openmax.com URL at the end"
 - "Switch to portrait 9:16"
 - "Change the style to cyberpunk"
 

--- a/docs/case-studies/shipping-group.md
+++ b/docs/case-studies/shipping-group.md
@@ -11,7 +11,7 @@ head:
       content: "A Southeast Asian shipping group that had already deployed 10+ AI employees but couldn't see what they were doing. How OpenMax Workspace solved the black-box problem, compressed cross-border routing from 10+ minutes to seconds, and upgraded agents from Q&A to end-to-end workflow automation."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -884,7 +884,7 @@ For the first time, management achieved real-time visibility into what their AI 
   <div class="case-cta">
     <h2>Let AI Transform Your Operations</h2>
     <p>From isolated AI tools to a coordinated AI workforce — start the conversation</p>
-    <a href="https://icoco.ai" class="cta-btn">Get Started with OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">Get Started with OpenMax</a>
   </div>
 </div>
 

--- a/docs/case-studies/social-media.md
+++ b/docs/case-studies/social-media.md
@@ -11,7 +11,7 @@ head:
       content: "Automate social media content and BD outreach with AI Agents. From one prompt to a full operations model — AI handles volume, humans handle strategy."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1018,7 +1018,7 @@ After the Singapore tech media team integrated OpenMax:
   <div class="case-cta">
     <h2>Let AI Take Over Your Content Volume</h2>
     <p>Start with a single message, build a complete operations model</p>
-    <a href="https://icoco.ai" class="cta-btn">Try OpenMax Free</a>
+    <a href="https://openmax.com" class="cta-btn">Try OpenMax Free</a>
   </div>
 </div>
 

--- a/docs/case-studies/tea-brand-franchise.md
+++ b/docs/case-studies/tea-brand-franchise.md
@@ -11,7 +11,7 @@ head:
       content: "How a global tea chain with ~60,000 stores deployed OpenMax AI to achieve 7×24 multilingual franchise inquiry coverage across Southeast Asia, auto-reply 60–80% of standard queries, and free up ~10 FTE."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -874,7 +874,7 @@ What makes OpenMax's deployment remarkable is not just the automation of inquiry
   <div class="case-cta">
     <h2>Never Miss Another Franchise Inquiry</h2>
     <p>Deploy AI employees that work 7x24 in every language your prospects speak</p>
-    <a href="https://icoco.ai" class="cta-btn">Get Started with OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">Get Started with OpenMax</a>
   </div>
 </div>
 

--- a/docs/case-studies/whatsapp-setup.md
+++ b/docs/case-studies/whatsapp-setup.md
@@ -14,7 +14,7 @@ You'll need to connect WhatsApp first. For setup instructions, see the [WhatsApp
 
 ### Step 1: Log in to Dashboard and Connect WhatsApp
 
-1. Log in to [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log in to [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Top right **Dashboard** → Left sidebar **Channels** → **WhatsApp** Connect
 3. Wait for the QR code to generate
 
@@ -77,4 +77,4 @@ The Bot will reach out to each person on the list, letting them know they can st
 
 ---
 
-Learn more: [icoco.ai](https://icoco.ai) Contact us: support@icoco.ai
+Learn more: [openmax.com](https://openmax.com) Contact us: support@icoco.ai

--- a/docs/channels/lark.md
+++ b/docs/channels/lark.md
@@ -77,5 +77,5 @@ Feishu and Lark share the same platform — the same OpenMax bot configuration w
 - Check that group mention mode is enabled in OpenMax Dashboard
 
 **Messages showing as "failed to send"?**
-- Check if the OpenMax service is online at [icoco.ai/dashboard](https://icoco.ai/dashboard)
+- Check if the OpenMax service is online at [openmax.com/dashboard](https://openmax.com/dashboard)
 - Verify your subscription is active

--- a/docs/channels/web-console.md
+++ b/docs/channels/web-console.md
@@ -58,7 +58,7 @@ Add the OpenMax widget script to your page:
     primaryColor: '#FFD646'
   };
 </script>
-<script src="https://icoco.ai/widget.js" async></script>
+<script src="https://openmax.com/widget.js" async></script>
 ```
 
 Configure widget settings in OpenMax Dashboard → Web Console → Embed Settings.

--- a/docs/getting-started/channel-deployment.md
+++ b/docs/getting-started/channel-deployment.md
@@ -58,7 +58,7 @@ Detailed guide for connecting your AI employee to Telegram or Lark.
 
 ### Step 2: Connect in OpenMax Dashboard
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Open the **Channels** page and find the **Telegram** card
 3. Paste the **Bot Token** from Step 1
 4. Click **Connect**
@@ -142,7 +142,7 @@ In the Developer Backend, find the **Create Lark Smart Agent App** banner at the
 
 <img :src="withBase('/lark-smart-agent-credentials.png')" alt="App Created page — copy App ID and App Secret" style="max-width: 520px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
 
-2. Log into [OpenMax Dashboard](https://icoco.ai/dashboard), click **Channels** on the left sidebar, select **Lark**, fill in the **App ID** and **App Secret**, then click **Connect** — the system will automatically deploy your AI employee (typically takes 2-3 minutes)
+2. Log into [OpenMax Dashboard](https://openmax.com/dashboard), click **Channels** on the left sidebar, select **Lark**, fill in the **App ID** and **App Secret**, then click **Connect** — the system will automatically deploy your AI employee (typically takes 2-3 minutes)
 
 <img :src="withBase('/lark-smart-agent-dashboard-channel.png')" alt="OpenMax Dashboard — fill in App ID and App Secret, click Connect" style="max-width: 520px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
 
@@ -301,7 +301,7 @@ In the app management page, go to **Permissions & Scopes**. Click **Batch Import
 
 ##### Step 7: Connect in OpenMax Dashboard and Deploy
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Go to the channel configuration page, select **Lark**
 3. Enter the following credentials:
 
@@ -373,7 +373,7 @@ In the Developer Backend, find the **Create Feishu Smart Agent App** banner at t
 
 ##### Step 4: Fill in Credentials in OpenMax Dashboard and Deploy
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Click **Channels** on the left sidebar, select **Feishu**
 
 <img :src="withBase('/feishu-smart-agent-dashboard-channel.png')" alt="OpenMax Dashboard — click Channels, select Feishu" style="max-width: 520px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
@@ -530,7 +530,7 @@ In the Permission Management page, copy the following JSON and import all permis
 
 ##### Step 5: Connect in OpenMax Dashboard and Deploy
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Go to the channel configuration page, select **Feishu**
 3. Enter the following credentials:
 
@@ -870,7 +870,7 @@ No credentials are required. You only need:
 
 ### Step 1: Create an AI Employee and Enter Configuration Page
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Create a new AI employee or select an existing instance
 3. Click **Configure →** on the employee card to enter the instance detail page
 
@@ -1316,7 +1316,7 @@ One credential is required:
 
 ### Step 2: Connect in OpenMax Dashboard
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Go to the employee instance detail page
 3. Find the **Zalo (Official)** card and click **Connect**
 4. Paste the **Bot Token** from Step 1
@@ -1454,7 +1454,7 @@ One credential is required:
 
 ### Step 5: Connect in OpenMax Dashboard
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Go to the employee instance detail page
 3. Find the **Discord** card and click **Connect**
 4. Paste the **Bot Token** from Step 2
@@ -1501,7 +1501,7 @@ LINE connects with two credentials — a **Channel Access Token** and a **Channe
 
 ### Step 3: Connect in OpenMax Dashboard
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard) and open the employee instance detail page (or the **Channels** step in the hire flow).
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard) and open the employee instance detail page (or the **Channels** step in the hire flow).
 2. Find the **LINE** card and click **Connect**.
 3. Paste the **Channel Access Token** and **Channel Secret** from Step 2.
 4. Click **Connect** — the system validates the token and deploys your LINE channel.
@@ -1543,7 +1543,7 @@ No credentials are required. Authentication is done entirely via QR code:
 
 ### Step 1: Click Connect on the Zalo Personal (Unofficial) Card
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard)
 2. Go to the employee instance detail page
 3. Find the **Zalo Personal (Unofficial)** card and click **Connect**
 4. The system will generate a QR code — this may take a few seconds
@@ -1595,7 +1595,7 @@ No credentials are required. You only need:
 
 ### Step 1: Click Connect on the WhatsApp Business Card
 
-1. Log into [OpenMax Dashboard](https://icoco.ai/dashboard) and open the employee instance detail page
+1. Log into [OpenMax Dashboard](https://openmax.com/dashboard) and open the employee instance detail page
 2. Find the **WhatsApp Business** card and click **Connect**
 
 ### Step 2: Enter Your Phone Number and Display Name

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -302,7 +302,7 @@ In short: ChatGPT is a smart Q&A tool. OpenMax is a digital employee that proact
 **Full Onboarding Flow (approximately 15 minutes)**
 
 1. Register an OpenMax account and choose a plan
-2. Follow the [Channel Deployment Guide](https://docs.icoco.ai) to connect your channel (Telegram: ~5 min; Lark: ~10 min; Zalo (Official): ~5 min)
+2. Follow the [Channel Deployment Guide](https://docs.openmax.com) to connect your channel (Telegram: ~5 min; Lark: ~10 min; Zalo (Official): ~5 min)
 3. Complete the Onboarding in the Dashboard (select your role; the AI employee initializes automatically)
 4. Send your first message and start collaborating
 

--- a/docs/getting-started/registration-payment.md
+++ b/docs/getting-started/registration-payment.md
@@ -21,7 +21,7 @@ Complete guide from registration to getting started.
 ## Step 1: Register / Login
 
 ### 1.1 Visit OpenMax Website
-- Open [icoco.ai](https://icoco.ai)
+- Open [openmax.com](https://openmax.com)
 - Click the **Login** button in the top right
 
 ### 1.2 Registration Methods
@@ -37,8 +37,8 @@ Complete guide from registration to getting started.
   - **Dashboard** — Management console
   - **Settings** — Personal settings
   - **Billing** — Subscription management
-  - **Use Cases** — View use cases (redirects to docs.icoco.ai)
-  - **Docs** — Help documentation (redirects to docs.icoco.ai)
+  - **Use Cases** — View use cases (redirects to docs.openmax.com)
+  - **Docs** — Help documentation (redirects to docs.openmax.com)
   - **Log out** — Sign out
 
 ---

--- a/docs/public/ms-teams-manifest/manifest.json
+++ b/docs/public/ms-teams-manifest/manifest.json
@@ -5,9 +5,9 @@
   "id": "<YOUR_APP_ID>",
   "developer": {
     "name": "<YOUR_COMPANY_NAME>",
-    "websiteUrl": "https://icoco.ai",
-    "privacyUrl": "https://icoco.ai/privacy",
-    "termsOfUseUrl": "https://icoco.ai/terms"
+    "websiteUrl": "https://openmax.com",
+    "privacyUrl": "https://docs.openmax.com/privacy-policy",
+    "termsOfUseUrl": "https://docs.openmax.com/user-agreement"
   },
   "name": { "short": "<YOUR_BOT_DISPLAY_NAME>" },
   "description": {

--- a/docs/social-media/channels.md
+++ b/docs/social-media/channels.md
@@ -2,14 +2,14 @@
 
 Follow us and connect with COCO across our platforms.
 
-## COCO (icoco.ai)
+## COCO (openmax.com)
 
 | Platform | Link | Status |
 |----------|------|--------|
 | **X / Twitter** | [@CocoAIxyz](https://x.com/CocoAIxyz) | Active |
 | **Telegram** | [COCO Support Group](https://t.me/cocoaixyz) | Active |
 | **Email** | support@icoco.ai | Active |
-| **Website** | [icoco.ai](https://icoco.ai) | Active |
+| **Website** | [openmax.com](https://openmax.com) | Active |
 | **TikTok** | @cocoaixyz | Active |
 | **LinkedIn** | [COCO AI](https://linkedin.com/company/cocoaixyz) | Active |
 

--- a/docs/social-media/index.md
+++ b/docs/social-media/index.md
@@ -2,14 +2,14 @@
 
 Follow us and connect with COCO across our platforms.
 
-## COCO (icoco.ai)
+## COCO (openmax.com)
 
 | Platform | Link | Status |
 |----------|------|--------|
 | **X / Twitter** | [@CocoAIxyz](https://x.com/CocoAIxyz) | Active |
 | **Telegram** | [COCO Support Group](https://t.me/cocoaixyz) | Active |
 | **Email** | support@icoco.ai | Active |
-| **Website** | [icoco.ai](https://icoco.ai) | Active |
+| **Website** | [openmax.com](https://openmax.com) | Active |
 | **TikTok** | @cocoaixyz | Active |
 | **LinkedIn** | [COCO AI](https://linkedin.com/company/cocoaixyz) | Active |
 

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -10,7 +10,7 @@ head:
       content: "Explore 1001 AI agent use cases for enterprise automation. From customer support to code review, see how OpenMax's multi-agent platform delivers 3-10x efficiency gains across industries."
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/use-cases-og.png"
+      content: "https://docs.openmax.com/use-cases-og.png"
   - - meta
     - property: og:type
       content: website
@@ -1148,7 +1148,7 @@ Enterprises typically see 3-10x efficiency gains from AI agent deployment, with 
 <details>
 <summary><strong>How does OpenMax compare to other AI agent platforms?</strong></summary>
 
-OpenMax is built on an open-source AI agent infrastructure (Zylos.ai) with an enterprise cloud layer (icoco.ai). Unlike DIY agent-building platforms, OpenMax provides a three-layer architecture: open-source framework, multi-agent orchestration (HXA Connect), and enterprise-ready deployment. OpenMax supports multi-agent team architectures where agents collaborate autonomously, works across both Western and Chinese markets, and integrates with the communication tools your team already uses (Slack, Lark/Feishu, Telegram, Microsoft Teams, and more).
+OpenMax is built on an open-source AI agent infrastructure (Zylos.ai) with an enterprise cloud layer (openmax.com). Unlike DIY agent-building platforms, OpenMax provides a three-layer architecture: open-source framework, multi-agent orchestration (HXA Connect), and enterprise-ready deployment. OpenMax supports multi-agent team architectures where agents collaborate autonomously, works across both Western and Chinese markets, and integrates with the communication tools your team already uses (Slack, Lark/Feishu, Telegram, Microsoft Teams, and more).
 
 </details>
 
@@ -1162,6 +1162,6 @@ Yes. OpenMax AI agents integrate natively with popular enterprise communication 
 <details>
 <summary><strong>Is there a free trial for OpenMax AI agent platform?</strong></summary>
 
-Yes, OpenMax offers a free trial so you can experience AI agent capabilities firsthand. Visit [icoco.ai](https://icoco.ai) to get started, or check our [Getting Started guide](/getting-started/) for step-by-step onboarding instructions. You can deploy your first AI agent team and see measurable results before committing to a plan.
+Yes, OpenMax offers a free trial so you can experience AI agent capabilities firsthand. Visit [openmax.com](https://openmax.com) to get started, or check our [Getting Started guide](/getting-started/) for step-by-step onboarding instructions. You can deploy your first AI agent team and see measurable results before committing to a plan.
 
 </details>

--- a/docs/zh/case-studies/browser-automation.md
+++ b/docs/zh/case-studies/browser-automation.md
@@ -99,7 +99,7 @@ AI 员工会给你一个 **网页链接** 和连接密码。
 ### 截图
 
 ```
-打开 https://icoco.ai 并截图发给我
+打开 https://openmax.com 并截图发给我
 ```
 
 ```
@@ -190,4 +190,4 @@ A：告诉 AI 员工「浏览器组件安装失败，帮我排查一下」，AI 
 
 ---
 
-了解更多：[icoco.ai](https://icoco.ai) 联系我们：support@icoco.ai
+了解更多：[openmax.com](https://openmax.com) 联系我们：support@icoco.ai

--- a/docs/zh/case-studies/building-materials.md
+++ b/docs/zh/case-studies/building-materials.md
@@ -11,7 +11,7 @@ head:
       content: "日均 200+ WhatsApp 消息、每天 30 张人工发票上限、动辄数千新元的 QS 外包费——新加坡建材经销商如何用 OpenMax AI 实现近零漏单、发票效率倍增、工程量清单从 1 周压缩到数小时。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -882,7 +882,7 @@ OpenMax 为该经销商搭建了覆盖前端客户沟通、发票处理和工程
   <div class="case-cta">
     <h2>让 AI 改变您的运营方式</h2>
     <p>从消息分拣到智能报价——从一次对话开始</p>
-    <a href="https://icoco.ai" class="cta-btn">开始使用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始使用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/crm.md
+++ b/docs/zh/case-studies/crm.md
@@ -11,7 +11,7 @@ head:
       content: "AI Agent 从零搭建并运营完整 CRM — 33% 转化率，零人工维护。企业 AI 自动化真实案例。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1200,7 +1200,7 @@ OpenMax AI Agent 通过与 Stripe 支付数据进行交叉验证来确保数据�
 
 ### Q: 如何让 OpenMax AI Agent 自动运营我们公司的 CRM？
 
-只需访问 icoco.ai 注册试用，向 AI Agent 描述你的业务需求和现有数据结构，它会帮你设计表格架构、搭建自动化流程、配置触发规则。整个过程不需要编程背景，也不需要 CRM 专业知识——用自然语言描述你想要什么即可。
+只需访问 openmax.com 注册试用，向 AI Agent 描述你的业务需求和现有数据结构，它会帮你设计表格架构、搭建自动化流程、配置触发规则。整个过程不需要编程背景，也不需要 CRM 专业知识——用自然语言描述你想要什么即可。
 
 </div>
 
@@ -1219,7 +1219,7 @@ OpenMax AI Agent 通过与 Stripe 支付数据进行交叉验证来确保数据�
   <div class="case-cta">
     <h2>让 AI 帮你搭建运营系统</h2>
     <p>像 OpenMax 一样，从一个需求描述开始</p>
-    <a href="https://icoco.ai" class="cta-btn">开始试用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始试用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/deal-flow-dd.md
+++ b/docs/zh/case-studies/deal-flow-dd.md
@@ -11,7 +11,7 @@ head:
       content: "AI Agent 投资尽调全流程自动化：数据室到 IC 备忘录，20 小时压缩到 2 小时，季度处理量 3 倍提升。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1300,7 +1300,7 @@ DD 完成后，OpenMax AI Agent 会持续监控已投或在审项目的关键信
 
 ### Q: OpenMax AI 的 DD 自动化方案如何收费？
 
-OpenMax AI Agent 按月订阅计费，不按处理的 DD 数量计费。具体方案请访问 icoco.ai 了解最新定价，或联系 OpenMax 团队咨询针对投资机构的企业方案。
+OpenMax AI Agent 按月订阅计费，不按处理的 DD 数量计费。具体方案请访问 openmax.com 了解最新定价，或联系 OpenMax 团队咨询针对投资机构的企业方案。
 
 </div>
 
@@ -1319,7 +1319,7 @@ OpenMax AI Agent 按月订阅计费，不按处理的 DD 数量计费。具体�
   <div class="case-cta">
     <h2>让 AI 接管你的数据室</h2>
     <p>专注找下一个好项目，文件的事交给 AI</p>
-    <a href="https://icoco.ai" class="cta-btn">开始试用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始试用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/email-automation.md
+++ b/docs/zh/case-studies/email-automation.md
@@ -11,7 +11,7 @@ head:
       content: "AI Agent 每 10 分钟扫描收件箱，智能分类、自动起草、人工审核 — 企业邮件管理自动化实战案例。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1184,7 +1184,7 @@ OpenMax AI Agent 可以扩展到多种企业邮件自动化场景：销售跟进
 
 ### Q: 如何开始配置 OpenMax AI Agent 的客服邮件自动化？
 
-访问 icoco.ai 注册试用，提供你的邮件服务器凭证（IMAP 地址、账号、App Password）、通知渠道（飞书账号）、品牌语气指南，以及真实用户邮件的识别标准。整个配置过程通过与 OpenMax AI Agent 的自然语言对话完成，通常在 30 分钟内可以完成初始配置并开始试运行。
+访问 openmax.com 注册试用，提供你的邮件服务器凭证（IMAP 地址、账号、App Password）、通知渠道（飞书账号）、品牌语气指南，以及真实用户邮件的识别标准。整个配置过程通过与 OpenMax AI Agent 的自然语言对话完成，通常在 30 分钟内可以完成初始配置并开始试运行。
 
 </div>
 
@@ -1203,7 +1203,7 @@ OpenMax AI Agent 可以扩展到多种企业邮件自动化场景：销售跟进
   <div class="case-cta">
     <h2>让 AI 守住你的收件箱</h2>
     <p>用户邮件一封不漏，回复质量你来把关</p>
-    <a href="https://icoco.ai" class="cta-btn">开始试用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始试用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/fmcg-collaboration.md
+++ b/docs/zh/case-studies/fmcg-collaboration.md
@@ -11,7 +11,7 @@ head:
       content: "覆盖东南亚 10+ 市场的快消品巨头如何用 OpenMax AI 打通 Lark 多群组协作，实现多语言自动调度、促销审批提速，并通过私有化部署满足严格数据合规要求。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -876,7 +876,7 @@ OpenMax AI 部署后，效果几乎立竿见影。AI 自动调度系统取代了
   <div class="case-cta">
     <h2>为你的企业协作引入 AI</h2>
     <p>像这家快消巨头一样，从团队已有的工具开始</p>
-    <a href="https://icoco.ai" class="cta-btn">开始使用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始使用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/game-studio.md
+++ b/docs/zh/case-studies/game-studio.md
@@ -11,7 +11,7 @@ head:
       content: "一个不足 10 人的游戏工作室如何用 OpenMax AI 构建 Agentic OS，打通 Google Workspace，让 3 个 AI 员工分别负责研发、市场与用户运营，从「用 AI 工具」升级为「AI 原生组织」。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -878,7 +878,7 @@ OpenMax 帮助工作室构建了一套 **Agentic OS（智能体操作系统）**
   <div class="case-cta">
     <h2>构建你的 AI 原生组织</h2>
     <p>像这家工作室一样，从统一 AI 操作层开始</p>
-    <a href="https://icoco.ai" class="cta-btn">开始使用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始使用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/hxa-team.md
+++ b/docs/zh/case-studies/hxa-team.md
@@ -11,7 +11,7 @@ head:
       content: "7 个 AI Agent 并行运行 — 从想法到上线仅需 20 分钟。多 Agent 企业 AI 自动化案例。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1098,7 +1098,7 @@ HxA 的价值不只是"AI 会写代码"。真正重要的是这支团队能并�
 
 ### Q: 如何开始搭建自己的多 Agent AI 团队？
 
-访问 icoco.ai 开始免费试用，向 AI Agent 描述你的团队结构和业务流程，它会帮你配置角色、协作规则和汇报流程。全程不需要编程基础。
+访问 openmax.com 开始免费试用，向 AI Agent 描述你的团队结构和业务流程，它会帮你配置角色、协作规则和汇报流程。全程不需要编程基础。
 
 </div>
 
@@ -1117,7 +1117,7 @@ HxA 的价值不只是"AI 会写代码"。真正重要的是这支团队能并�
   <div class="case-cta">
     <h2>把 1 个 AI 员工，扩成 1 支可管理的 AI 团队</h2>
     <p>你负责业务方向，执行、协作与交付交给 OpenMax。</p>
-    <a href="https://icoco.ai" class="cta-btn">开始试用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始试用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/index.md
+++ b/docs/zh/case-studies/index.md
@@ -177,4 +177,4 @@ OpenMax不是聊天机器人，是你的全职AI员工。你在Telegram、飞书
 
 ---
 
-了解更多：[icoco.ai](https://icoco.ai) 联系我们：support@icoco.ai
+了解更多：[openmax.com](https://openmax.com) 联系我们：support@icoco.ai

--- a/docs/zh/case-studies/manufacturing-ai.md
+++ b/docs/zh/case-studies/manufacturing-ai.md
@@ -11,7 +11,7 @@ head:
       content: "制造业 AI 案例：四大痛点，四套实战方案。企业 AI 自动化在工厂的真正落地。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1027,7 +1027,7 @@ OpenMax 提供三层安全保障：ISO/SOC2 认证 + 全程加密传输、Agent 
   <div class="case-cta">
     <h2>让 AI 走进你的工厂</h2>
     <p>从一个真实问题开始，找到属于你的落地方案</p>
-    <a href="https://icoco.ai" class="cta-btn">开始试用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始试用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/regtech-company.md
+++ b/docs/zh/case-studies/regtech-company.md
@@ -11,7 +11,7 @@ head:
       content: "一家横跨亚太与中东的 RegTech 企业，对外卖 AI 合规平台，对内却靠人工推送法规、三套系统割裂、客户数据零沉淀——直到用 OpenMax AI 把自己也变成 AI 驱动的公司。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -878,7 +878,7 @@ OpenMax 带来的不仅是运营效率的提升，更是战略层面的对齐。
   <div class="case-cta">
     <h2>说到做到，从自身开始</h2>
     <p>像你向客户倡导的那样，把 AI 带进自己的运营</p>
-    <a href="https://icoco.ai" class="cta-btn">开始使用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始使用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/seedance-video.md
+++ b/docs/zh/case-studies/seedance-video.md
@@ -102,7 +102,7 @@ OpenMax AI 员工会调用 Seedance Skill，输出专业的视频提示词（含
 
 Review 提示词，按需修改。例如：
 
-- 「最后加上 icoco.ai 网址」
+- 「最后加上 openmax.com 网址」
 - 「换成竖屏 9:16」
 - 「风格改成赛博朋克」
 

--- a/docs/zh/case-studies/shipping-group.md
+++ b/docs/zh/case-studies/shipping-group.md
@@ -11,7 +11,7 @@ head:
       content: "已部署 10+ AI 员工的海运集团，如何通过 OpenMax Workspace 解决「看不见 AI 在干什么」的黑盒问题，实现跨组织路由从 10 分钟压缩到秒级，Agent 从问答升级为工作流自动化。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -884,7 +884,7 @@ OpenMax 为该集团部署了 OpenMax Workspace 协作层，在现有 AI 员工�
   <div class="case-cta">
     <h2>让 AI 改变您的运营方式</h2>
     <p>从孤立的 AI 工具到协同的 AI 团队——从一次对话开始</p>
-    <a href="https://icoco.ai" class="cta-btn">开始使用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始使用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/social-media.md
+++ b/docs/zh/case-studies/social-media.md
@@ -11,7 +11,7 @@ head:
       content: "AI Agent 自动化社媒内容创作与 BD 外联。从一条 prompt 到完整运营模型 — AI 扛产量，人管策略。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -1018,7 +1018,7 @@ OpenMax 和她一起设计了覆盖市场、BD、销售运营的全套工作流�
   <div class="case-cta">
     <h2>让 AI 接管你的内容产量</h2>
     <p>从一条消息开始，构建完整运营模型</p>
-    <a href="https://icoco.ai" class="cta-btn">开始试用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始试用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/tea-brand-franchise.md
+++ b/docs/zh/case-studies/tea-brand-franchise.md
@@ -11,7 +11,7 @@ head:
       content: "全球约 6 万家门店的头部茶饮品牌如何借助 OpenMax AI，实现东南亚加盟咨询 7×24 自动响应，释放约 10 个 FTE，60–80% 标准化问题全自动回复。"
   - - meta
     - property: og:image
-      content: "https://docs.icoco.ai/coco-logo-black.png"
+      content: "https://docs.openmax.com/coco-logo-black.png"
 ---
 
 <style>
@@ -874,7 +874,7 @@ OpenMax 部署的真正亮点不仅在于咨询处理的自动化——而在于
   <div class="case-cta">
     <h2>不再错过任何一条加盟咨询</h2>
     <p>部署全天候、全语言的 AI 数字员工</p>
-    <a href="https://icoco.ai" class="cta-btn">开始使用 OpenMax</a>
+    <a href="https://openmax.com" class="cta-btn">开始使用 OpenMax</a>
   </div>
 </div>
 

--- a/docs/zh/case-studies/whatsapp-setup.md
+++ b/docs/zh/case-studies/whatsapp-setup.md
@@ -14,7 +14,7 @@
 
 ### 第一步：登录 Dashboard 连接 WhatsApp
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 右上角【Dashboard】→ 左侧【Channels】→ 【WhatsApp】Connect
 3. 等待二维码生成
 
@@ -77,4 +77,4 @@ Bot 会逐一给名单上的每个人发送消息，告知他们可以直接提�
 
 ---
 
-了解更多：[icoco.ai](https://icoco.ai) 联系我们：support@icoco.ai
+了解更多：[openmax.com](https://openmax.com) 联系我们：support@icoco.ai

--- a/docs/zh/channels/lark.md
+++ b/docs/zh/channels/lark.md
@@ -77,5 +77,5 @@
 - 检查 OpenMax Dashboard 中是否已启用群聊提及模式
 
 **消息显示"发送失败"？**
-- 前往 [icoco.ai/dashboard](https://icoco.ai/dashboard) 检查 OpenMax 服务是否在线
+- 前往 [openmax.com/dashboard](https://openmax.com/dashboard) 检查 OpenMax 服务是否在线
 - 确认你的订阅状态正常

--- a/docs/zh/channels/web-console.md
+++ b/docs/zh/channels/web-console.md
@@ -58,7 +58,7 @@ https://[你的域名].icoco.ai/console/
     primaryColor: '#FFD646'
   };
 </script>
-<script src="https://icoco.ai/widget.js" async></script>
+<script src="https://openmax.com/widget.js" async></script>
 ```
 
 在 OpenMax Dashboard → Web 控制台 → 嵌入设置 中配置挂件参数。

--- a/docs/zh/getting-started/channel-deployment.md
+++ b/docs/zh/getting-started/channel-deployment.md
@@ -60,7 +60,7 @@ import { withBase } from 'vitepress'
 
 #### 第2步：在OpenMax Dashboard绑定
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 进入 **对话入口** 页面，找到 **Telegram** 卡片
 3. 粘贴上一步获取的 **Bot Token**
 4. 点击 **连接**
@@ -140,7 +140,7 @@ Lark（海外版）和飞书（国内版）的操作流程略有不同，请根�
 
 ##### 第4步：在 OpenMax Dashboard 填写凭证并部署
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 点击左侧的「对话入口」，选择 **飞书**
 
 <img :src="withBase('/feishu-smart-agent-dashboard-channel.png')" alt="OpenMax Dashboard — 点击「对话入口」，选择飞书" style="max-width: 520px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
@@ -355,7 +355,7 @@ Lark（海外版）和飞书（国内版）的操作流程略有不同，请根�
 
 ##### 第7步：在 OpenMax Dashboard 填写凭证并部署
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 点击左侧的「对话入口」，选择 **飞书**
 
 <img :src="withBase('/coco-dashboard-feishu-channel.png')" alt="OpenMax Dashboard — 点击「对话入口」，选择飞书" style="max-width: 520px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
@@ -442,7 +442,7 @@ Lark 提供两种部署方式，请根据你的需求选择：
 
 ##### 第4步：在 OpenMax Dashboard 填写凭证并部署
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 点击左侧的「对话入口」，选择 **Lark（飞书国际版）**
 
 <img :src="withBase('/lark-smart-agent-dashboard-channel.png')" alt="OpenMax Dashboard — 点击「对话入口」，选择 Lark" style="max-width: 520px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
@@ -657,7 +657,7 @@ Lark 提供两种部署方式，请根据你的需求选择：
 
 ##### 第7步：在 OpenMax Dashboard 填写凭证并部署
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 点击左侧的「对话入口」，选择 **Lark**
 
 <img :src="withBase('/coco-dashboard-lark-channel.png')" alt="OpenMax Dashboard — 点击「对话入口」，选择 Lark" style="max-width: 520px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
@@ -701,7 +701,7 @@ Lark 提供两种部署方式，请根据你的需求选择：
 
 ### 第2步：登录 Dashboard → 对话入口 → 微信连接 → 微信扫码（附截图）
 
-<a href="https://icoco.ai/dashboard" style="color: #f5a623; font-weight: 600;">登录 Dashboard</a> → 对话入口 → 选择微信连接 → 待二维码生成 → 手机微信扫码即可
+<a href="https://openmax.com/dashboard" style="color: #f5a623; font-weight: 600;">登录 Dashboard</a> → 对话入口 → 选择微信连接 → 待二维码生成 → 手机微信扫码即可
 
 <img :src="withBase('/wechat-dashboard-connect.png')" alt="OpenMax Dashboard 对话入口 — 点击微信连接按钮，扫码完成绑定" style="max-width: 720px; width: 100%; border-radius: 8px; margin: 0.5rem 0;" />
 
@@ -1008,7 +1008,7 @@ Bot 需要独立身份。只有使用专属号码，其他人才能把它当作�
 
 ### 第1步：创建 AI 员工并进入配置页面
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 创建新的 AI 员工，或选择已有实例
 3. 点击员工卡片上的 **配置 →** 进入实例详情页
 
@@ -1433,7 +1433,7 @@ Bot 需要独立身份。只有使用专属号码，其他人才能把它当作�
 
 ### 第2步：在 OpenMax Dashboard 中连接
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 进入员工实例详情页
 3. 找到 **Zalo (官方)** 卡片，点击 **Connect**（连接）
 4. 粘贴第1步获取的 **Bot Token**
@@ -1571,7 +1571,7 @@ AI 员工会确认连接已建立。你的专用 Zalo 账号现在是 Bot 在 Za
 
 ### 第5步：在 OpenMax Dashboard 中连接
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 进入员工实例详情页
 3. 找到 **Discord** 卡片，点击 **Connect**（连接）
 4. 粘贴第2步获取的 **Bot Token**
@@ -1618,7 +1618,7 @@ LINE 通过两个凭证连接——**Channel Access Token**（通道访问令牌
 
 #### 第3步：在 OpenMax Dashboard 绑定
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)，进入员工实例详情页（或雇佣流程中的 **对话入口** 步骤）。
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)，进入员工实例详情页（或雇佣流程中的 **对话入口** 步骤）。
 2. 找到 **LINE** 卡片，点击 **连接**。
 3. 粘贴第2步获取的 **Channel Access Token** 和 **Channel Secret**。
 4. 点击 **连接**——系统会验证令牌并部署你的 LINE 通道。
@@ -1660,7 +1660,7 @@ LINE 通过两个凭证连接——**Channel Access Token**（通道访问令牌
 
 ### 第1步：点击 Zalo 个人版（非官方） 卡片的「连接」
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)
 2. 进入员工实例详情页
 3. 找到 **Zalo 个人版（非官方）** 卡片，点击 **连接**
 4. 系统将生成二维码——可能需要几秒钟
@@ -1712,7 +1712,7 @@ LINE 通过两个凭证连接——**Channel Access Token**（通道访问令牌
 
 ### 第1步：点击 WhatsApp Business 卡片的「连接」
 
-1. 登录 [OpenMax Dashboard](https://icoco.ai/dashboard)，进入员工实例详情页
+1. 登录 [OpenMax Dashboard](https://openmax.com/dashboard)，进入员工实例详情页
 2. 找到 **WhatsApp Business** 卡片，点击 **连接**
 
 ### 第2步：输入电话号码和显示名称

--- a/docs/zh/getting-started/faq.md
+++ b/docs/zh/getting-started/faq.md
@@ -302,7 +302,7 @@ AI 员工会告诉你当前的支持情况和推荐的接入方式。
 **完整流程（约 15 分钟）**
 
 1. 注册 OpenMax 账号并选择套餐
-2. 参考 [渠道部署指南](https://docs.icoco.ai) 完成渠道连接（Telegram 约 5 分钟；Lark 约 10 分钟；Zalo (官方) 约 5 分钟）
+2. 参考 [渠道部署指南](https://docs.openmax.com) 完成渠道连接（Telegram 约 5 分钟；Lark 约 10 分钟；Zalo (官方) 约 5 分钟）
 3. 在 Dashboard 完成 Onboarding（选择你的角色，AI 员工自动初始化）
 4. 发送第一条消息，开始协作
 

--- a/docs/zh/getting-started/registration-payment.md
+++ b/docs/zh/getting-started/registration-payment.md
@@ -21,7 +21,7 @@
 ## 步骤1：注册 / 登录
 
 ### 1.1 访问OpenMax官网
-- 打开 [icoco.ai](https://icoco.ai)
+- 打开 [openmax.com](https://openmax.com)
 - 点击右上角 **Login** 按钮
 
 ### 1.2 注册方式
@@ -37,8 +37,8 @@
   - **Dashboard** — 进入管理后台
   - **Settings** — 个人设置
   - **Billing** — 账单与套餐管理
-  - **Use Cases** — 查看使用案例（跳转 docs.icoco.ai）
-  - **Docs** — 帮助文档（跳转 docs.icoco.ai）
+  - **Use Cases** — 查看使用案例（跳转 docs.openmax.com）
+  - **Docs** — 帮助文档（跳转 docs.openmax.com）
   - **Log out** — 退出登录
 
 ---

--- a/docs/zh/social-media/channels.md
+++ b/docs/zh/social-media/channels.md
@@ -2,14 +2,14 @@
 
 关注我们，在各平台与COCO保持连接。
 
-## COCO (icoco.ai)
+## COCO (openmax.com)
 
 | 平台 | 链接 | 状态 |
 |------|------|------|
 | **X / Twitter** | [@CocoAIxyz](https://x.com/CocoAIxyz) | 主要运营中 |
 | **Telegram客服群** | [COCO Support Group](https://t.me/cocoaixyz) | 运营中 |
 | **邮箱** | support@icoco.ai | 运营中 |
-| **官网** | [icoco.ai](https://icoco.ai) | 运营中 |
+| **官网** | [openmax.com](https://openmax.com) | 运营中 |
 | **TikTok** | @cocoaixyz | 运营中 |
 | **LinkedIn** | [COCO AI](https://linkedin.com/company/cocoaixyz) | 运营中 |
 

--- a/docs/zh/social-media/index.md
+++ b/docs/zh/social-media/index.md
@@ -2,14 +2,14 @@
 
 关注我们，在各平台与COCO保持连接。
 
-## COCO (icoco.ai)
+## COCO (openmax.com)
 
 | 平台 | 链接 | 状态 |
 |------|------|------|
 | **X / Twitter** | [@CocoAIxyz](https://x.com/CocoAIxyz) | 主要运营中 |
 | **Telegram客服群** | [COCO Support Group](https://t.me/cocoaixyz) | 运营中 |
 | **邮箱** | support@icoco.ai | 运营中 |
-| **官网** | [icoco.ai](https://icoco.ai) | 运营中 |
+| **官网** | [openmax.com](https://openmax.com) | 运营中 |
 | **TikTok** | @cocoaixyz | 运营中 |
 | **LinkedIn** | [COCO AI](https://linkedin.com/company/cocoaixyz) | 运营中 |
 


### PR DESCRIPTION
Replaces icoco.ai link targets with openmax.com equivalents across EN+ZH docs (49 files, 116 replacements). Requested by zhigang.hao (cc bill.li), ref 「OpenMax旧站SEO页面301部署参考-2026-08-04」.

## Changed (all new targets verified HTTP 200)
- `https://docs.icoco.ai/...` → `https://docs.openmax.com/...` (incl. og-image asset URLs)
- `https://icoco.ai` / bare `icoco.ai` mentions → `openmax.com` (incl. `/dashboard`)
- `icoco.ai/privacy` & `icoco.ai/terms` (currently 301→404 **broken**) → `docs.openmax.com/privacy-policy` / `user-agreement` (in ms-teams manifest.json)
- Widget embed: `https://icoco.ai/widget.js` → `https://openmax.com/widget.js` (verified live); `window.COCO_CONFIG` untouched

## Intentionally NOT changed (flagged for decision)
- **@icoco.ai emails** (service@/support@, 26 occurrences) — whether these mailboxes exist on openmax.com needs confirmation
- **announcements/new-domain-icoco-ai** (EN+ZH) + its nav/index titles — historical announcement about the icoco.ai launch
- **privacy-policy / user-agreement** page content — legal wording pending entity-name confirmation
- **`*.icoco.ai` customer-instance patterns** (`[your-domain].icoco.ai/console`, `<subdomain>.icoco.ai/line/webhook`) — functional endpoints, changing them could break real instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)